### PR TITLE
Ocp4846 version

### DIFF
--- a/aws/bootnode-ami/prepare-bootnode-ami.sh
+++ b/aws/bootnode-ami/prepare-bootnode-ami.sh
@@ -32,13 +32,13 @@ mv jq /usr/local/bin
 dnf module install -y container-tools
 
 ## Download Openshift CLI and move to /usr/local/bin
-wget "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.8.11/openshift-client-linux-4.8.11.tar.gz"
-tar -xvf openshift-client-linux-4.8.11.tar.gz
+wget "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.8.46/openshift-client-linux-4.8.46.tar.gz"
+tar -xvf openshift-client-linux-4.8.46.tar.gz
 chmod u+x oc kubectl
 mv oc /usr/local/bin
 mv kubectl /usr/local/bin
 oc version
-rm -rf openshift-client-linux-4.8.11.tar.gz
+rm -rf openshift-client-linux-4.8.46.tar.gz
 
 ## Install terraform
 TERRAFORM_VER=`curl -s https://api.github.com/repos/hashicorp/terraform/releases/latest |  grep tag_name | cut -d: -f2 | tr -d \"\,\v | awk '{$1=$1};1'`

--- a/aws/ocp-terraform/linux-prereq-install.sh
+++ b/aws/ocp-terraform/linux-prereq-install.sh
@@ -20,8 +20,8 @@ mv jq /usr/local/bin
 
 ## Download Openshift CLI and move to /usr/local/bin
 
-wget "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.8.11/openshift-client-linux-4.8.11.tar.gz"
-tar -xvf openshift-client-linux-4.8.11.tar.gz
+wget "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.8.46/openshift-client-linux-4.8.46.tar.gz"
+tar -xvf openshift-client-linux-4.8.46.tar.gz
 chmod u+x oc kubectl
 sudo mv oc /usr/local/bin
 sudo mv kubectl /usr/local/bin

--- a/aws/ocp-terraform/mac-prereq-install.sh
+++ b/aws/ocp-terraform/mac-prereq-install.sh
@@ -20,8 +20,8 @@ mv jq /usr/local/bin
 
 ## Download Openshift CLI and move to /usr/local/bin
 
-wget "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.8.11/openshift-client-mac-4.8.11.tar.gz"
-tar -xvf openshift-client-mac-4.8.11.tar.gz
+wget "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.8.46/openshift-client-mac-4.8.46.tar.gz"
+tar -xvf openshift-client-mac-4.8.46.tar.gz
 chmod u+x oc kubectl
 sudo mv oc /usr/local/bin
 sudo mv kubectl /usr/local/bin

--- a/aws/ocp-terraform/ocp/variables.tf
+++ b/aws/ocp-terraform/ocp/variables.tf
@@ -5,7 +5,7 @@ variable "openshift_installer_url" {
 
 variable "openshift_version" {
   type = string
-  default = "4.8.24"
+  default = "4.8.46"
 }
 
 variable "cluster_name" {

--- a/aws/ocp-terraform/variables.tf
+++ b/aws/ocp-terraform/variables.tf
@@ -331,7 +331,7 @@ variable "cloudctl_version" {
 
 variable "openshift_version" {
   description = "OCP Version"
-  default     = "4.8.24"
+  default     = "4.8.46"
 }
 
 variable "cpd_platform" {

--- a/azure/bootnode-image/prepare-bootnode-image.sh
+++ b/azure/bootnode-image/prepare-bootnode-image.sh
@@ -12,10 +12,10 @@
 #     If you have specified value for ANSIBLE_COLLECTION_VERSION, this parameter will be ignored.
 #     If you do not specify values for either ANSIBLE_COLLECTION_VERSION or ANSIBLE_COLLECTION_BRANCH, the Ansible collection will be
 #     built locally from the master branch of Ansible collection repo, and installed.
-#   BOOTSTRAP_AUTOMATION_TAG_OR_BRANCH: If you want to build the image with specific bootstrap automation code tag or branch, provide that value. 
+#   BOOTSTRAP_AUTOMATION_TAG_OR_BRANCH: If you want to build the image with specific bootstrap automation code tag or branch, provide that value.
 #     Specific branch is normally used when testing the changes from your feature branch.
 #     Specific tag is normally used when the bootstrap code is locked for a specific release.
-#     
+#
 set -e
 
 ANSIBLE_COLLECTION_VERSION=$1
@@ -51,7 +51,7 @@ gpgcheck=1
 gpgkey=https://packages.microsoft.com/keys/microsoft.asc" | tee /etc/yum.repos.d/azure-cli.repo
 dnf install azure-cli -y
 
-# Install AzureCopy cli 
+# Install AzureCopy cli
 wget -q https://aka.ms/downloadazcopy-v10-linux -O azcopy_linux_amd64.tar.gz
 tar -xzvf azcopy_linux_amd64.tar.gz
 mv -f azcopy_linux_amd64_*/azcopy /usr/sbin
@@ -67,12 +67,12 @@ mv jq /usr/local/bin
 dnf module install -y container-tools
 
 ## Download Openshift CLI and move to /usr/local/bin
-wget -q "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.8.11/openshift-client-linux-4.8.11.tar.gz"
-tar -xvf openshift-client-linux-4.8.11.tar.gz
+wget -q "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.8.46/openshift-client-linux-4.8.46.tar.gz"
+tar -xvf openshift-client-linux-4.8.46.tar.gz
 chmod u+x oc kubectl
 mv oc /usr/local/bin
 mv kubectl /usr/local/bin
-rm -rf openshift-client-linux-4.8.11.tar.gz
+rm -rf openshift-client-linux-4.8.46.tar.gz
 
 ## Install terraform
 TERRAFORM_VER=`curl -s https://api.github.com/repos/hashicorp/terraform/releases/latest |  grep tag_name | cut -d: -f2 | tr -d \"\,\v | awk '{$1=$1};1'`
@@ -108,7 +108,7 @@ else
 fi
 
 # Get the bootstrap github code
-cd /root 
+cd /root
 rm -rf ansible-devops
 mkdir -p ansible-devops
 cd ansible-devops

--- a/azure/ocp-terraform/azure_infra/variables.tf
+++ b/azure/ocp-terraform/azure_infra/variables.tf
@@ -77,7 +77,7 @@ variable "worker-subnet-cidr" {
   default = "10.0.2.0/24"
 }
 
-#Bastion host variable 
+#Bastion host variable
 variable "bastion_cidr" {
   default = "10.0.3.224/27"
 }
@@ -141,7 +141,7 @@ variable "ssh-public-key" {
 variable "private-or-public-cluster" {
   default = "public"
 }
-#For MAS keeping storage as ocs 
+#For MAS keeping storage as ocs
 #Other options are portworx and nfs
 variable "storage" {
   default = "ocs"
@@ -179,7 +179,7 @@ variable "cpd-external-username" {
   default     = "cp"
 }
 variable "ocp_version" {
-  default = "4.8.11"
+  default = "4.8.46"
 }
 
 
@@ -232,7 +232,7 @@ variable "rwo_cpd_storageclass" {
   }
 }
 ############################################
-# CPD 4.0 service variables 
+# CPD 4.0 service variables
 ###########################################
 variable "cpd_platform" {
   type = map(string)


### PR DESCRIPTION
Made these changes to verify stack creation on OCP 4.8.46. Verified this change by creating a stack (MAS+CP4D) on AWS & it got created successfully.
Also, executed FVT tests & there were no failures. Please see below screenshots.
Made this change in prepare-bootnode-ami.sh, linux-prereq-install.sh, & mac-prereq-install.sh files too to use OCP client 4.8.46 version.

![image](https://user-images.githubusercontent.com/57617912/178311774-86fe4373-56ea-4d0a-a162-2ab268eefd06.png)

![image](https://user-images.githubusercontent.com/57617912/178311995-f119b7e9-741d-415d-8ae8-1534dcb68d54.png)

![image](https://user-images.githubusercontent.com/57617912/178312189-61c93bbb-2597-4f52-a736-228fe2af5ee7.png)
