### PR TITLE
Removed redundant blank spaces between double-quotes for default values

### DIFF
--- a/aws/master-cft/byol-existing-ocp/cft-mas-core-dev.json
+++ b/aws/master-cft/byol-existing-ocp/cft-mas-core-dev.json
@@ -730,7 +730,7 @@
                                 {
                                     "Ref": "AWS::AccountId"
                                 },
-                                "\" \"\" \"",
+                                "\" \"",
                                 "\" \"",
                                 {
                                     "Fn::GetAtt": [
@@ -753,9 +753,9 @@
                                 {
                                     "Ref": "DeployWaitConditionHandle"
                                 },
-                                "\" \"\" \"",
+                                "\" \"",
                                 "\" ",
-                                "\" \"\" \"",
+                                "'",
                                 "' '",
                                 {
                                     "Ref": "MASLicenseUrl"

--- a/aws/master-cft/byol-existing-ocp/cft-mas-core-dev.json
+++ b/aws/master-cft/byol-existing-ocp/cft-mas-core-dev.json
@@ -34,6 +34,12 @@
             "Type": "String",
             "NoEcho": true
         },
+        "EntitledRegistryKey": {
+            "Description": "Enter the registry key that you downloaded from the IBM Container Library.",
+            "Type": "String",
+            "NoEcho": true,
+            "MinLength": "1"
+        },
         "MASLicenseUrl": {
             "Description": "Enter the HTTP or S3 location of your Suite license key file, for example: s3://masocp-license/entitlement.lic",
             "Type": "String",
@@ -146,6 +152,7 @@
                         "default": "Keys and licenses (you must complete this section)"
                     },
                     "Parameters": [
+                        "EntitledRegistryKey",
                         "MASLicenseUrl"
                     ]
                 },
@@ -754,6 +761,9 @@
                                     "Ref": "DeployWaitConditionHandle"
                                 },
                                 "\" \"",
+                                {
+                                    "Ref": "EntitledRegistryKey"
+                                },
                                 "\" ",
                                 "'",
                                 "' '",

--- a/aws/master-cft/byol-existing-ocp/cft-mas-core.json
+++ b/aws/master-cft/byol-existing-ocp/cft-mas-core.json
@@ -730,7 +730,7 @@
                                 {
                                     "Ref": "AWS::AccountId"
                                 },
-                                "\" \"\" \"",
+                                "\" \"",
                                 "\" \"",
                                 {
                                     "Fn::GetAtt": [
@@ -753,9 +753,9 @@
                                 {
                                     "Ref": "DeployWaitConditionHandle"
                                 },
-                                "\" \"\" \"",
+                                "\" \"",
                                 "\" ",
-                                "\" \"\" \"",
+                                "'",
                                 "' '",
                                 {
                                     "Ref": "MASLicenseUrl"

--- a/aws/master-cft/byol-existing-ocp/cft-mas-core.json
+++ b/aws/master-cft/byol-existing-ocp/cft-mas-core.json
@@ -34,6 +34,12 @@
             "Type": "String",
             "NoEcho": true
         },
+        "EntitledRegistryKey": {
+            "Description": "Enter the registry key that you downloaded from the IBM Container Library.",
+            "Type": "String",
+            "NoEcho": true,
+            "MinLength": "1"
+        },
         "MASLicenseUrl": {
             "Description": "Enter the HTTP or S3 location of your Suite license key file, for example: s3://masocp-license/entitlement.lic",
             "Type": "String",
@@ -146,6 +152,7 @@
                         "default": "Keys and licenses (you must complete this section)"
                     },
                     "Parameters": [
+                        "EntitledRegistryKey",
                         "MASLicenseUrl"
                     ]
                 },
@@ -754,6 +761,9 @@
                                     "Ref": "DeployWaitConditionHandle"
                                 },
                                 "\" \"",
+                                {
+                                    "Ref": "EntitledRegistryKey"
+                                },
                                 "\" ",
                                 "'",
                                 "' '",


### PR DESCRIPTION
Some of the values in CFT for BYoL on existing OCP are not needed and had incorrectly been assigned blank spaces. Those have been removed now