### PR TITLE
Changed the displayed URLs in Outputs tab due to TECSEV3-1

### DIFF
--- a/aws/master-cft/byol-existing-ocp/cft-mas-core-dev.json
+++ b/aws/master-cft/byol-existing-ocp/cft-mas-core-dev.json
@@ -886,7 +886,7 @@
                 "Fn::Join": [
                     "",
                     [
-                        "https://admin.mas-",
+                        "https://admin.",
                         {
                             "Fn::GetAtt": [
                                 "CallLambdaRandomizer",
@@ -916,7 +916,7 @@
                 "Fn::Join": [
                     "",
                     [
-                        "https://admin.mas-",
+                        "https://admin.",
                         {
                             "Fn::GetAtt": [
                                 "CallLambdaRandomizer",
@@ -945,7 +945,7 @@
                 "Fn::Join": [
                     "",
                     [
-                        "https://wsmasocp.home.mas-",
+                        "https://wsmasocp.home.",
                         {
                             "Fn::GetAtt": [
                                 "CallLambdaRandomizer",

--- a/aws/master-cft/byol-existing-ocp/cft-mas-core.json
+++ b/aws/master-cft/byol-existing-ocp/cft-mas-core.json
@@ -885,7 +885,7 @@
                 "Fn::Join": [
                     "",
                     [
-                        "https://admin.mas-",
+                        "https://admin.",
                         {
                             "Fn::GetAtt": [
                                 "CallLambdaRandomizer",
@@ -915,7 +915,7 @@
                 "Fn::Join": [
                     "",
                     [
-                        "https://admin.mas-",
+                        "https://admin.",
                         {
                             "Fn::GetAtt": [
                                 "CallLambdaRandomizer",
@@ -944,7 +944,7 @@
                 "Fn::Join": [
                     "",
                     [
-                        "https://wsmasocp.home.mas-",
+                        "https://wsmasocp.home.",
                         {
                             "Fn::GetAtt": [
                                 "CallLambdaRandomizer",


### PR DESCRIPTION
[TECSEV3-1](https://github.ibm.com/wiotp/tracker/issues/9562) demanded changing the URL, which was done in the scripts earlier. This should also be carried out in the CFTs. The current code drop handles this code change in CFTs.