### PR TITLE
CFT Updates

### DIFF
--- a/aws/master-cft/byol-existing-ocp/cft-mas-core-dev.json
+++ b/aws/master-cft/byol-existing-ocp/cft-mas-core-dev.json
@@ -848,7 +848,7 @@
     "Outputs": {
         "MASCloudAutomationVersion": {
             "Description": "Version of the MAS automated deployment on Cloud",
-            "Value": "2.0-alpha.1"
+            "Value": "2.0"
         },
         "MASInitialSetupUrlLogin": {
             "Description": "Url to perform MAS initial setup, make sure you have imported the MAS public certificate into the browser",

--- a/aws/master-cft/byol-existing-ocp/cft-mas-core-dev.json
+++ b/aws/master-cft/byol-existing-ocp/cft-mas-core-dev.json
@@ -12,10 +12,6 @@
                 "MAS Core + Manage (no Cloud Pak for Data)"
             ]
         },
-        "PublicHostedZone": {
-            "Description": "Select the public hosted zone that you created in the AWS Route 53 service, for example: mas4aws.myorg.com",
-            "Type": "AWS::Route53::HostedZone::Id"
-        },
         "BootNodeVPCId": {
             "Description": "Enter the VPC Id to create the bootnode into. Default VPC created by AWS will be used if not specified. If existing OpenShift cluster is specified, make sure it is reachable from this VPC",
             "Type" : "AWS::EC2::VPC::Id"
@@ -140,14 +136,6 @@
                         "OpenShiftClusterApiUrl",
                         "OpenShiftUser",
                         "OpenShiftPassword"
-                    ]
-                },
-                {
-                    "Label": {
-                        "default": "Existing OpenShift cluster configuration details (you must complete this section)"
-                    },
-                    "Parameters": [
-                        "PublicHostedZone"
                     ]
                 },
                 {
@@ -560,23 +548,6 @@
                 }
             }
         },
-        "CallLambdaGetHostedZoneName": {
-            "Type": "Custom::CallLambdaGetHostedZoneName",
-            "Properties": {
-                "ServiceToken": {
-                    "Fn::GetAtt": [
-                        "LambdaFunctionGetHostedZoneName",
-                        "Arn"
-                    ]
-                },
-                "ZoneId": {
-                    "Ref": "PublicHostedZone"
-                },
-                "Region": {
-                    "Ref": "AWS::Region"
-                }
-            }
-        },
         "DeploymentConfigBucket": {
             "Type": "AWS::S3::Bucket",
             "Properties": {
@@ -755,13 +726,8 @@
                                     ]
                                 },
                                 "\" \"",
-                                {
-                                    "Fn::GetAtt": [
-                                        "CallLambdaGetHostedZoneName",
-                                        "ZoneName"
-                                    ]
-                                },
-                                "\" \"\" \"",
+                                "\" \"",
+                                "\" \"",
                                 {
                                     "Ref": "SSHKey"
                                 },

--- a/aws/master-cft/byol-existing-ocp/cft-mas-core.json
+++ b/aws/master-cft/byol-existing-ocp/cft-mas-core.json
@@ -848,7 +848,7 @@
     "Outputs": {
         "MASCloudAutomationVersion": {
             "Description": "Version of the MAS automated deployment on Cloud",
-            "Value": "2.0-alpha.1"
+            "Value": "2.0"
         },
         "MASInitialSetupUrlLogin": {
             "Description": "Url to perform MAS initial setup, make sure you have imported the MAS public certificate into the browser",

--- a/aws/master-cft/byol-existing-ocp/cft-mas-core.json
+++ b/aws/master-cft/byol-existing-ocp/cft-mas-core.json
@@ -12,10 +12,6 @@
                 "MAS Core + Manage (no Cloud Pak for Data)"
             ]
         },
-        "PublicHostedZone": {
-            "Description": "Select the public hosted zone that you created in the AWS Route 53 service, for example: mas4aws.myorg.com",
-            "Type": "AWS::Route53::HostedZone::Id"
-        },
         "BootNodeVPCId": {
             "Description": "Enter the VPC Id to create the bootnode into. Default VPC created by AWS will be used if not specified. If existing OpenShift cluster is specified, make sure it is reachable from this VPC",
             "Type" : "AWS::EC2::VPC::Id"
@@ -31,6 +27,7 @@
             "MaxLength": "18",
             "AllowedPattern": "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})/(\\d{1,2})",
             "ConstraintDescription": "must be a valid IP CIDR range of the form w.x.y.z/a."
+
         },
         "OpenShiftClusterApiUrl": {
             "Description": "Enter the cluster's URL in the format https://api.<cluster_name>.<domain_name>. Do not specify the port number. For example,https://api.masocp.joalae.mas4aws.com",
@@ -139,14 +136,6 @@
                         "OpenShiftClusterApiUrl",
                         "OpenShiftUser",
                         "OpenShiftPassword"
-                    ]
-                },
-                {
-                    "Label": {
-                        "default": "Existing OpenShift cluster configuration details (you must complete this section)"
-                    },
-                    "Parameters": [
-                        "PublicHostedZone"
                     ]
                 },
                 {
@@ -559,23 +548,6 @@
                 }
             }
         },
-        "CallLambdaGetHostedZoneName": {
-            "Type": "Custom::CallLambdaGetHostedZoneName",
-            "Properties": {
-                "ServiceToken": {
-                    "Fn::GetAtt": [
-                        "LambdaFunctionGetHostedZoneName",
-                        "Arn"
-                    ]
-                },
-                "ZoneId": {
-                    "Ref": "PublicHostedZone"
-                },
-                "Region": {
-                    "Ref": "AWS::Region"
-                }
-            }
-        },
         "DeploymentConfigBucket": {
             "Type": "AWS::S3::Bucket",
             "Properties": {
@@ -754,13 +726,8 @@
                                     ]
                                 },
                                 "\" \"",
-                                {
-                                    "Fn::GetAtt": [
-                                        "CallLambdaGetHostedZoneName",
-                                        "ZoneName"
-                                    ]
-                                },
-                                "\" \"\" \"",
+                                "\" \"",
+                                "\" \"",
                                 {
                                     "Ref": "SSHKey"
                                 },

--- a/aws/master-cft/byol-ipi/cft-mas-core-dev.json
+++ b/aws/master-cft/byol-ipi/cft-mas-core-dev.json
@@ -865,7 +865,7 @@
     "Outputs": {
         "MASCloudAutomationVersion": {
             "Description": "Version of the MAS automated deployment on Cloud",
-            "Value": "1.0"
+            "Value": "2.0"
         },
         "ClusterUniqueString": {
             "Description": "Unique string that is part of cluster resoutce names",

--- a/aws/master-cft/byol-ipi/cft-mas-core-dev.json
+++ b/aws/master-cft/byol-ipi/cft-mas-core-dev.json
@@ -212,7 +212,7 @@
             "eu-north-1": {
                 "HVM64": "ami-0b3a8c8ed376a9193"
             },
-            
+
 	    "eu-west-1": {
                 "HVM64": "ami-0fb132ff756953f9a"
             },
@@ -817,7 +817,7 @@
                                 "' '",
                                 {
                                     "Ref": "ImportDemoData"
-                                },                                
+                                },
                                 "' '' '' '' '' '",
                                 {
                                     "Ref": "EmailNotification"
@@ -931,7 +931,7 @@
                 "Fn::Join": [
                     "",
                     [
-                        "https://admin.mas-",
+                        "https://admin.",
                         {
                             "Fn::GetAtt": [
                                 "CallLambdaRandomizer",
@@ -963,7 +963,7 @@
                 "Fn::Join": [
                     "",
                     [
-                        "https://admin.mas-",
+                        "https://admin.",
                         {
                             "Fn::GetAtt": [
                                 "CallLambdaRandomizer",
@@ -995,7 +995,7 @@
                 "Fn::Join": [
                     "",
                     [
-                        "https://admin.mas-",
+                        "https://admin.",
                         {
                             "Fn::GetAtt": [
                                 "CallLambdaRandomizer",
@@ -1057,7 +1057,7 @@
                 "Fn::Join": [
                     "",
                     [
-                        "https://wsmasocp.home.mas-",
+                        "https://wsmasocp.home",
                         {
                             "Fn::GetAtt": [
                                 "CallLambdaRandomizer",
@@ -1088,7 +1088,7 @@
                 "Fn::Join": [
                     "",
                     [
-                        "https://wsmasocp.home.mas-",
+                        "https://wsmasocp.home",
                         {
                             "Fn::GetAtt": [
                                 "CallLambdaRandomizer",

--- a/aws/master-cft/byol-ipi/cft-mas-core.json
+++ b/aws/master-cft/byol-ipi/cft-mas-core.json
@@ -212,7 +212,7 @@
             "eu-north-1": {
                 "HVM64": "ami-xxxxxxxxxxxxxxxxx"
             },
-            
+
             "eu-west-1": {
                 "HVM64": "ami-xxxxxxxxxxxxxxxxx"
             },
@@ -246,7 +246,7 @@
             "sa-east-1": {
                 "HVM64": "ami-xxxxxxxxxxxxxxxxx"
             }
-        
+
         }
     },
     "Resources": {
@@ -822,7 +822,7 @@
                                 "' '' '' '' '' '",
 
                                 {
-                                   
+
                                     "Ref": "EmailNotification"
                                 },
                                 "' '' '' '' '' '' '' '' '' '' '' '' '' '' '' '' '' '' '' '' '",
@@ -934,7 +934,7 @@
                 "Fn::Join": [
                     "",
                     [
-                        "https://admin.mas-",
+                        "https://admin.",
                         {
                             "Fn::GetAtt": [
                                 "CallLambdaRandomizer",
@@ -966,7 +966,7 @@
                 "Fn::Join": [
                     "",
                     [
-                        "https://admin.mas-",
+                        "https://admin.",
                         {
                             "Fn::GetAtt": [
                                 "CallLambdaRandomizer",
@@ -998,7 +998,7 @@
                 "Fn::Join": [
                     "",
                     [
-                        "https://admin.mas-",
+                        "https://admin.",
                         {
                             "Fn::GetAtt": [
                                 "CallLambdaRandomizer",
@@ -1060,7 +1060,7 @@
                 "Fn::Join": [
                     "",
                     [
-                        "https://wsmasocp.home.mas-",
+                        "https://wsmasocp.home",
                         {
                             "Fn::GetAtt": [
                                 "CallLambdaRandomizer",
@@ -1091,7 +1091,7 @@
                 "Fn::Join": [
                     "",
                     [
-                        "https://wsmasocp.home.mas-",
+                        "https://wsmasocp.home",
                         {
                             "Fn::GetAtt": [
                                 "CallLambdaRandomizer",

--- a/aws/master-cft/byol-ipi/cft-mas-core.json
+++ b/aws/master-cft/byol-ipi/cft-mas-core.json
@@ -868,7 +868,7 @@
     "Outputs": {
         "MASCloudAutomationVersion": {
             "Description": "Version of the MAS automated deployment on Cloud",
-            "Value": "1.0"
+            "Value": "2.0"
         },
         "ClusterUniqueString": {
             "Description": "Unique string that is part of cluster resoutce names",

--- a/aws/master-cft/byol-upi/cft-mas-core-dev.json
+++ b/aws/master-cft/byol-upi/cft-mas-core-dev.json
@@ -919,7 +919,7 @@
     "Outputs": {
         "MASCloudAutomationVersion": {
             "Description": "Version of the MAS automated deployment on Cloud",
-            "Value": "2.0-alpha.1"
+            "Value": "2.0"
         },
         "ClusterUniqueString": {
             "Description": "Unique string that is part of cluster resoutce names",

--- a/aws/master-cft/byol-upi/cft-mas-core.json
+++ b/aws/master-cft/byol-upi/cft-mas-core.json
@@ -919,7 +919,7 @@
     "Outputs": {
         "MASCloudAutomationVersion": {
             "Description": "Version of the MAS automated deployment on Cloud",
-            "Value": "2.0-alpha.1"
+            "Value": "2.0"
         },
         "ClusterUniqueString": {
             "Description": "Unique string that is part of cluster resoutce names",

--- a/aws/master-cft/paid-existing-ocp/cft-mas-core-dev.json
+++ b/aws/master-cft/paid-existing-ocp/cft-mas-core-dev.json
@@ -838,7 +838,7 @@
     "Outputs": {
         "MASCloudAutomationVersion": {
             "Description": "Version of the MAS automated deployment on Cloud",
-            "Value": "2.0-alpha.1"
+            "Value": "2.0"
         },
         "MASInitialSetupUrlLogin": {
             "Description": "Url to perform MAS initial setup, make sure you have imported the MAS public certificate into the browser",

--- a/aws/master-cft/paid-existing-ocp/cft-mas-core.json
+++ b/aws/master-cft/paid-existing-ocp/cft-mas-core.json
@@ -838,7 +838,7 @@
     "Outputs": {
         "MASCloudAutomationVersion": {
             "Description": "Version of the MAS automated deployment on Cloud",
-            "Value": "2.0-alpha.1"
+            "Value": "2.0"
         },
         "MASInitialSetupUrlLogin": {
             "Description": "Url to perform MAS initial setup, make sure you have imported the MAS public certificate into the browser",

--- a/aws/master-cft/paid-ipi/cft-mas-core-dev.json
+++ b/aws/master-cft/paid-ipi/cft-mas-core-dev.json
@@ -32,19 +32,6 @@
                 "large"
             ]
         },
-        "OpenShiftClusterApiUrl": {
-            "Description": "Enter the cluster's URL in the format https://api.<cluster_name>.<domain_name>. Do not specify the port number. For example,https://api.masocp.joalae.mas4aws.com",
-            "Type": "String"
-        },
-        "OpenShiftUser": {
-            "Description": "Enter the username of the existing cluster account.",
-            "Type": "String"
-        },
-        "OpenShiftPassword": {
-            "Description": "Enter the password of the existing cluster account.",
-            "Type": "String",
-            "NoEcho": true
-        },
         "EntitledRegistryKey": {
             "Description": "Enter the registry key that you downloaded from the IBM Container Library.",
             "Type": "String",
@@ -130,16 +117,6 @@
                     },
                     "Parameters": [
                         "OfferingType"
-                    ]
-                },
-                {
-                    "Label": {
-                        "default": "Existing OpenShift cluster connection details (complete this section only if you want to reuse an existing cluster)"
-                    },
-                    "Parameters": [
-                        "OpenShiftClusterApiUrl",
-                        "OpenShiftUser",
-                        "OpenShiftPassword"
                     ]
                 },
                 {
@@ -262,28 +239,6 @@
             "sa-east-1": {
                 "HVM64": "ami-037608508e4c078cd"
             }
-        }
-    },
-    "Conditions": {
-        "NoExistingOCPCluster": {
-            "Fn::Equals": [
-                {
-                    "Ref": "OpenShiftClusterApiUrl"
-                },
-                ""
-            ]
-        },
-        "ExistingOCPCluster": {
-            "Fn::Not": [
-                {
-                    "Fn::Equals": [
-                        {
-                            "Ref": "OpenShiftClusterApiUrl"
-                        },
-                        ""
-                    ]
-                }
-            ]
         }
     },
     "Resources": {
@@ -851,20 +806,8 @@
                                 "' '",
                                 {
                                     "Ref": "ImportDemoData"
-                                },
-                                "' '",
-                                {
-                                    "Ref": "OpenShiftClusterApiUrl"
-                                },
-                                "' '",
-                                {
-                                    "Ref": "OpenShiftUser"
-                                },
-                                "' '",
-                                {
-                                    "Ref": "OpenShiftPassword"
-                                },
-                                "' '' '",
+                                },                                
+                                "' '' '' '' '' '",
                                 {
                                     "Ref": "EmailNotification"
                                 },
@@ -924,7 +867,6 @@
         },
         "OpenShiftConsoleUrl": {
             "Description": "Url to login to OpenShift console",
-            "Condition": "NoExistingOCPCluster",
             "Value": {
                 "Fn::Join": [
                     "",
@@ -949,7 +891,6 @@
         },
         "OpenShiftApiUrl": {
             "Description": "Url to login to OpenShift Api",
-            "Condition": "NoExistingOCPCluster",
             "Value": {
                 "Fn::Join": [
                     "",
@@ -975,7 +916,6 @@
         },
         "MASInitialSetupUrl": {
             "Description": "Url to perform MAS initial setup, make sure you have imported the MAS public certificate into the browser",
-            "Condition": "NoExistingOCPCluster",
             "Value": {
                 "Fn::Join": [
                     "",
@@ -1008,7 +948,6 @@
         },
         "MASInitialSetupUrlLogin": {
             "Description": "Url to perform MAS initial setup, make sure you have imported the MAS public certificate into the browser",
-            "Condition": "ExistingOCPCluster",
             "Value": {
                 "Fn::Join": [
                     "",
@@ -1022,14 +961,16 @@
                         },
                         ".apps.",
                         {
-                            "Fn::Select": [
-                                "1",
-                                {
-                                    "Fn::Split": [
-                                        "api.",
-                                        {"Ref": "OpenShiftClusterApiUrl"}
-                                    ]
-                                }
+                            "Fn::GetAtt": [
+                                "CallLambdaRandomizer",
+                                "Lower_RandomString"
+                            ]
+                        },
+                        ".",
+                        {
+                            "Fn::GetAtt": [
+                                "CallLambdaGetHostedZoneName",
+                                "ZoneName"
                             ]
                         },
                         "/initialsetup"
@@ -1039,7 +980,6 @@
         },
         "MASAdminUrl": {
             "Description": "Url to login to MAS Admin UI, make sure you have imported the MAS public certificate into the browser",
-            "Condition": "NoExistingOCPCluster",
             "Value": {
                 "Fn::Join": [
                     "",
@@ -1071,28 +1011,29 @@
         },
         "MASAdminUrlLogin": {
             "Description": "Url to login to MAS Admin UI, make sure you have imported the MAS public certificate into the browser",
-            "Condition": "ExistingOCPCluster",
             "Value": {
                 "Fn::Join": [
                     "",
                     [
-                        "https://admin.mas-",
+                        "https://admin.",
                         {
                             "Fn::GetAtt": [
                                 "CallLambdaRandomizer",
                                 "Lower_RandomString"
                             ]
                         },
-                        ".apps.",
+                        ".apps.masocp-",
                         {
-                            "Fn::Select": [
-                                "1",
-                                {
-                                    "Fn::Split": [
-                                        "api.",
-                                        {"Ref": "OpenShiftClusterApiUrl"}
-                                    ]
-                                }
+                            "Fn::GetAtt": [
+                                "CallLambdaRandomizer",
+                                "Lower_RandomString"
+                            ]
+                        },
+                        ".",
+                        {
+                            "Fn::GetAtt": [
+                                "CallLambdaGetHostedZoneName",
+                                "ZoneName"
                             ]
                         }
                     ]
@@ -1101,7 +1042,6 @@
         },
         "MASWorkspaceUrl": {
             "Description": "Url to login to MAS Workspace, make sure you have imported the MAS public certificate into the browser",
-            "Condition": "NoExistingOCPCluster",
             "Value": {
                 "Fn::Join": [
                     "",
@@ -1133,7 +1073,6 @@
         },
         "MASWorkspaceUrlLogin": {
             "Description": "Url to login to MAS Workspace, make sure you have imported the MAS public certificate into the browser",
-            "Condition": "ExistingOCPCluster",
             "Value": {
                 "Fn::Join": [
                     "",
@@ -1147,14 +1086,16 @@
                         },
                         ".apps.",
                         {
-                            "Fn::Select": [
-                                "1",
-                                {
-                                    "Fn::Split": [
-                                        "api.",
-                                        {"Ref": "OpenShiftClusterApiUrl"}
-                                    ]
-                                }
+                            "Fn::GetAtt": [
+                                "CallLambdaRandomizer",
+                                "Lower_RandomString"
+                            ]
+                        },
+                        ".",
+                        {
+                            "Fn::GetAtt": [
+                                "CallLambdaGetHostedZoneName",
+                                "ZoneName"
                             ]
                         }
                     ]

--- a/aws/master-cft/paid-ipi/cft-mas-core-dev.json
+++ b/aws/master-cft/paid-ipi/cft-mas-core-dev.json
@@ -806,7 +806,7 @@
                                 "' '",
                                 {
                                     "Ref": "ImportDemoData"
-                                },                                
+                                },
                                 "' '' '' '' '' '",
                                 {
                                     "Ref": "EmailNotification"
@@ -920,7 +920,7 @@
                 "Fn::Join": [
                     "",
                     [
-                        "https://admin.mas-",
+                        "https://admin.",
                         {
                             "Fn::GetAtt": [
                                 "CallLambdaRandomizer",
@@ -952,7 +952,7 @@
                 "Fn::Join": [
                     "",
                     [
-                        "https://admin.mas-",
+                        "https://admin.",
                         {
                             "Fn::GetAtt": [
                                 "CallLambdaRandomizer",
@@ -984,7 +984,7 @@
                 "Fn::Join": [
                     "",
                     [
-                        "https://admin.mas-",
+                        "https://admin.",
                         {
                             "Fn::GetAtt": [
                                 "CallLambdaRandomizer",
@@ -1046,7 +1046,7 @@
                 "Fn::Join": [
                     "",
                     [
-                        "https://wsmasocp.home.mas-",
+                        "https://wsmasocp.home",
                         {
                             "Fn::GetAtt": [
                                 "CallLambdaRandomizer",
@@ -1077,7 +1077,7 @@
                 "Fn::Join": [
                     "",
                     [
-                        "https://wsmasocp.home.mas-",
+                        "https://wsmasocp.home",
                         {
                             "Fn::GetAtt": [
                                 "CallLambdaRandomizer",

--- a/aws/master-cft/paid-ipi/cft-mas-core-dev.json
+++ b/aws/master-cft/paid-ipi/cft-mas-core-dev.json
@@ -854,7 +854,7 @@
     "Outputs": {
         "MASCloudAutomationVersion": {
             "Description": "Version of the MAS automated deployment on Cloud",
-            "Value": "1.0"
+            "Value": "2.0"
         },
         "ClusterUniqueString": {
             "Description": "Unique string that is part of cluster resoutce names",

--- a/aws/master-cft/paid-ipi/cft-mas-core.json
+++ b/aws/master-cft/paid-ipi/cft-mas-core.json
@@ -32,19 +32,6 @@
                 "large"
             ]
         },
-        "OpenShiftClusterApiUrl": {
-            "Description": "Enter the cluster's URL in the format https://api.<cluster_name>.<domain_name>. Do not specify the port number. For example,https://api.masocp.joalae.mas4aws.com",
-            "Type": "String"
-        },
-        "OpenShiftUser": {
-            "Description": "Enter the username of the existing cluster account.",
-            "Type": "String"
-        },
-        "OpenShiftPassword": {
-            "Description": "Enter the password of the existing cluster account.",
-            "Type": "String",
-            "NoEcho": true
-        },
         "EntitledRegistryKey": {
             "Description": "Enter the registry key that you downloaded from the IBM Container Library.",
             "Type": "String",
@@ -130,16 +117,6 @@
                     },
                     "Parameters": [
                         "OfferingType"
-                    ]
-                },
-                {
-                    "Label": {
-                        "default": "Existing OpenShift cluster connection details (complete this section only if you want to reuse an existing cluster)"
-                    },
-                    "Parameters": [
-                        "OpenShiftClusterApiUrl",
-                        "OpenShiftUser",
-                        "OpenShiftPassword"
                     ]
                 },
                 {
@@ -262,28 +239,7 @@
             "sa-east-1": {
                 "HVM64": "ami-xxxxxxxxxxxxxxxxx"
             }
-        }
-    },
-    "Conditions": {
-        "NoExistingOCPCluster": {
-            "Fn::Equals": [
-                {
-                    "Ref": "OpenShiftClusterApiUrl"
-                },
-                ""
-            ]
-        },
-        "ExistingOCPCluster": {
-            "Fn::Not": [
-                {
-                    "Fn::Equals": [
-                        {
-                            "Ref": "OpenShiftClusterApiUrl"
-                        },
-                        ""
-                    ]
-                }
-            ]
+        
         }
     },
     "Resources": {
@@ -852,20 +808,10 @@
                                 {
                                     "Ref": "ImportDemoData"
                                 },
-                                "' '",
+                                "' '' '' '' '' '",
+
                                 {
-                                    "Ref": "OpenShiftClusterApiUrl"
-                                },
-                                "' '",
-                                {
-                                    "Ref": "OpenShiftUser"
-                                },
-                                "' '",
-                                {
-                                    "Ref": "OpenShiftPassword"
-                                },
-                                "' '' '",
-                                {
+                                   
                                     "Ref": "EmailNotification"
                                 },
                                 "' '' '' '' '' '' '' '' '' '' '' '' '' '' '' '' '' '' '' '' '",
@@ -924,7 +870,6 @@
         },
         "OpenShiftConsoleUrl": {
             "Description": "Url to login to OpenShift console",
-            "Condition": "NoExistingOCPCluster",
             "Value": {
                 "Fn::Join": [
                     "",
@@ -949,7 +894,6 @@
         },
         "OpenShiftApiUrl": {
             "Description": "Url to login to OpenShift Api",
-            "Condition": "NoExistingOCPCluster",
             "Value": {
                 "Fn::Join": [
                     "",
@@ -975,7 +919,6 @@
         },
         "MASInitialSetupUrl": {
             "Description": "Url to perform MAS initial setup, make sure you have imported the MAS public certificate into the browser",
-            "Condition": "NoExistingOCPCluster",
             "Value": {
                 "Fn::Join": [
                     "",
@@ -1008,7 +951,6 @@
         },
         "MASInitialSetupUrlLogin": {
             "Description": "Url to perform MAS initial setup, make sure you have imported the MAS public certificate into the browser",
-            "Condition": "ExistingOCPCluster",
             "Value": {
                 "Fn::Join": [
                     "",
@@ -1022,14 +964,16 @@
                         },
                         ".apps.",
                         {
-                            "Fn::Select": [
-                                "1",
-                                {
-                                    "Fn::Split": [
-                                        "api.",
-                                        {"Ref": "OpenShiftClusterApiUrl"}
-                                    ]
-                                }
+                            "Fn::GetAtt": [
+                                "CallLambdaRandomizer",
+                                "Lower_RandomString"
+                            ]
+                        },
+                        ".",
+                        {
+                            "Fn::GetAtt": [
+                                "CallLambdaGetHostedZoneName",
+                                "ZoneName"
                             ]
                         },
                         "/initialsetup"
@@ -1039,7 +983,6 @@
         },
         "MASAdminUrl": {
             "Description": "Url to login to MAS Admin UI, make sure you have imported the MAS public certificate into the browser",
-            "Condition": "NoExistingOCPCluster",
             "Value": {
                 "Fn::Join": [
                     "",
@@ -1071,28 +1014,29 @@
         },
         "MASAdminUrlLogin": {
             "Description": "Url to login to MAS Admin UI, make sure you have imported the MAS public certificate into the browser",
-            "Condition": "ExistingOCPCluster",
             "Value": {
                 "Fn::Join": [
                     "",
                     [
-                        "https://admin.mas-",
+                        "https://admin.",
                         {
                             "Fn::GetAtt": [
                                 "CallLambdaRandomizer",
                                 "Lower_RandomString"
                             ]
                         },
-                        ".apps.",
+                        ".apps.masocp-",
                         {
-                            "Fn::Select": [
-                                "1",
-                                {
-                                    "Fn::Split": [
-                                        "api.",
-                                        {"Ref": "OpenShiftClusterApiUrl"}
-                                    ]
-                                }
+                            "Fn::GetAtt": [
+                                "CallLambdaRandomizer",
+                                "Lower_RandomString"
+                            ]
+                        },
+                        ".",
+                        {
+                            "Fn::GetAtt": [
+                                "CallLambdaGetHostedZoneName",
+                                "ZoneName"
                             ]
                         }
                     ]
@@ -1101,7 +1045,6 @@
         },
         "MASWorkspaceUrl": {
             "Description": "Url to login to MAS Workspace, make sure you have imported the MAS public certificate into the browser",
-            "Condition": "NoExistingOCPCluster",
             "Value": {
                 "Fn::Join": [
                     "",
@@ -1133,7 +1076,6 @@
         },
         "MASWorkspaceUrlLogin": {
             "Description": "Url to login to MAS Workspace, make sure you have imported the MAS public certificate into the browser",
-            "Condition": "ExistingOCPCluster",
             "Value": {
                 "Fn::Join": [
                     "",
@@ -1147,14 +1089,16 @@
                         },
                         ".apps.",
                         {
-                            "Fn::Select": [
-                                "1",
-                                {
-                                    "Fn::Split": [
-                                        "api.",
-                                        {"Ref": "OpenShiftClusterApiUrl"}
-                                    ]
-                                }
+                            "Fn::GetAtt": [
+                                "CallLambdaRandomizer",
+                                "Lower_RandomString"
+                            ]
+                        },
+                        ".",
+                        {
+                            "Fn::GetAtt": [
+                                "CallLambdaGetHostedZoneName",
+                                "ZoneName"
                             ]
                         }
                     ]

--- a/aws/master-cft/paid-ipi/cft-mas-core.json
+++ b/aws/master-cft/paid-ipi/cft-mas-core.json
@@ -857,7 +857,7 @@
     "Outputs": {
         "MASCloudAutomationVersion": {
             "Description": "Version of the MAS automated deployment on Cloud",
-            "Value": "1.0"
+            "Value": "2.0"
         },
         "ClusterUniqueString": {
             "Description": "Unique string that is part of cluster resoutce names",

--- a/aws/master-cft/paid-ipi/cft-mas-core.json
+++ b/aws/master-cft/paid-ipi/cft-mas-core.json
@@ -239,7 +239,7 @@
             "sa-east-1": {
                 "HVM64": "ami-xxxxxxxxxxxxxxxxx"
             }
-        
+
         }
     },
     "Resources": {
@@ -811,7 +811,7 @@
                                 "' '' '' '' '' '",
 
                                 {
-                                   
+
                                     "Ref": "EmailNotification"
                                 },
                                 "' '' '' '' '' '' '' '' '' '' '' '' '' '' '' '' '' '' '' '' '",
@@ -923,7 +923,7 @@
                 "Fn::Join": [
                     "",
                     [
-                        "https://admin.mas-",
+                        "https://admin.",
                         {
                             "Fn::GetAtt": [
                                 "CallLambdaRandomizer",
@@ -955,7 +955,7 @@
                 "Fn::Join": [
                     "",
                     [
-                        "https://admin.mas-",
+                        "https://admin.",
                         {
                             "Fn::GetAtt": [
                                 "CallLambdaRandomizer",
@@ -987,7 +987,7 @@
                 "Fn::Join": [
                     "",
                     [
-                        "https://admin.mas-",
+                        "https://admin.",
                         {
                             "Fn::GetAtt": [
                                 "CallLambdaRandomizer",
@@ -1049,7 +1049,7 @@
                 "Fn::Join": [
                     "",
                     [
-                        "https://wsmasocp.home.mas-",
+                        "https://wsmasocp.home",
                         {
                             "Fn::GetAtt": [
                                 "CallLambdaRandomizer",
@@ -1080,7 +1080,7 @@
                 "Fn::Join": [
                     "",
                     [
-                        "https://wsmasocp.home.mas-",
+                        "https://wsmasocp.home",
                         {
                             "Fn::GetAtt": [
                                 "CallLambdaRandomizer",

--- a/aws/master-cft/paid-upi/cft-mas-core-dev.json
+++ b/aws/master-cft/paid-upi/cft-mas-core-dev.json
@@ -49,7 +49,6 @@
             "Type": "String",
             "MinLength": "9",
             "MaxLength": "18",
-            "Default": "0.0.0.0/0",
             "AllowedPattern": "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})/(\\d{1,2})",
             "ConstraintDescription": "must be a valid IP CIDR range of the form w.x.y.z/a."
         },
@@ -229,7 +228,7 @@
                 },
                 {
                     "Label": {
-                        "default": "Choose the OCP cluster type  & existing VPC Details"
+                        "default": "Choose the OCP cluster type  & existing VPC Details "
                     },
                     "Parameters": [
                         "PrivateCluster",
@@ -868,7 +867,6 @@
                                 {
                                     "Ref": "PrivateCluster"
                                 },
-                                "' '",
                                 "' \"dev\" ",
                                 "2>&1 | tee mas-provisioning.log; "
                             ]
@@ -911,7 +909,7 @@
     "Outputs": {
         "MASCloudAutomationVersion": {
             "Description": "Version of the MAS automated deployment on Cloud",
-            "Value": "1.0"
+            "Value": "2.0-alpha.1"
         },
         "ClusterUniqueString": {
             "Description": "Unique string that is part of cluster resoutce names",
@@ -977,7 +975,7 @@
                 "Fn::Join": [
                     "",
                     [
-                        "https://admin.mas-",
+                        "https://admin.",
                         {
                             "Fn::GetAtt": [
                                 "CallLambdaRandomizer",
@@ -1009,7 +1007,7 @@
                 "Fn::Join": [
                     "",
                     [
-                        "https://admin.mas-",
+                        "https://admin.",
                         {
                             "Fn::GetAtt": [
                                 "CallLambdaRandomizer",
@@ -1040,7 +1038,7 @@
                 "Fn::Join": [
                     "",
                     [
-                        "https://wsmasocp.home.mas-",
+                        "https://wsmasocp.home.",
                         {
                             "Fn::GetAtt": [
                                 "CallLambdaRandomizer",

--- a/aws/master-cft/paid-upi/cft-mas-core-dev.json
+++ b/aws/master-cft/paid-upi/cft-mas-core-dev.json
@@ -909,7 +909,7 @@
     "Outputs": {
         "MASCloudAutomationVersion": {
             "Description": "Version of the MAS automated deployment on Cloud",
-            "Value": "2.0-alpha.1"
+            "Value": "2.0"
         },
         "ClusterUniqueString": {
             "Description": "Unique string that is part of cluster resoutce names",

--- a/aws/master-cft/paid-upi/cft-mas-core.json
+++ b/aws/master-cft/paid-upi/cft-mas-core.json
@@ -49,7 +49,6 @@
             "Type": "String",
             "MinLength": "9",
             "MaxLength": "18",
-            "Default": "0.0.0.0/0",
             "AllowedPattern": "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})/(\\d{1,2})",
             "ConstraintDescription": "must be a valid IP CIDR range of the form w.x.y.z/a."
         },
@@ -229,7 +228,7 @@
                 },
                 {
                     "Label": {
-                        "default": "Choose the OCP cluster type  & existing VPC Details"
+                        "default": "Choose the OCP cluster type  & existing VPC Details "
                     },
                     "Parameters": [
                         "PrivateCluster",
@@ -868,7 +867,6 @@
                                 {
                                     "Ref": "PrivateCluster"
                                 },
-                                "' '",
                                 "' \"prod\" ",
                                 "2>&1 | tee mas-provisioning.log; "
                             ]
@@ -911,7 +909,7 @@
     "Outputs": {
         "MASCloudAutomationVersion": {
             "Description": "Version of the MAS automated deployment on Cloud",
-            "Value": "1.0"
+            "Value": "2.0-alpha.1"
         },
         "ClusterUniqueString": {
             "Description": "Unique string that is part of cluster resoutce names",
@@ -977,7 +975,7 @@
                 "Fn::Join": [
                     "",
                     [
-                        "https://admin.mas-",
+                        "https://admin.",
                         {
                             "Fn::GetAtt": [
                                 "CallLambdaRandomizer",
@@ -1009,7 +1007,7 @@
                 "Fn::Join": [
                     "",
                     [
-                        "https://admin.mas-",
+                        "https://admin.",
                         {
                             "Fn::GetAtt": [
                                 "CallLambdaRandomizer",
@@ -1040,7 +1038,7 @@
                 "Fn::Join": [
                     "",
                     [
-                        "https://wsmasocp.home.mas-",
+                        "https://wsmasocp.home.",
                         {
                             "Fn::GetAtt": [
                                 "CallLambdaRandomizer",

--- a/aws/master-cft/paid-upi/cft-mas-core.json
+++ b/aws/master-cft/paid-upi/cft-mas-core.json
@@ -909,7 +909,7 @@
     "Outputs": {
         "MASCloudAutomationVersion": {
             "Description": "Version of the MAS automated deployment on Cloud",
-            "Value": "2.0-alpha.1"
+            "Value": "2.0"
         },
         "ClusterUniqueString": {
             "Description": "Unique string that is part of cluster resoutce names",

--- a/helper.sh
+++ b/helper.sh
@@ -186,7 +186,7 @@ split_ocp_api_url() {
 validate_prouduct_type() {
   product_code_metadata="$(curl http://169.254.169.254/latest/meta-data/product-codes)"
   # Hardcoding product_code_metadata for testing purpose until ami gets created for paid product.
-  product_code_metadata="1905n4jwbijcylk3xm02poizl"
+  # product_code_metadata="1905n4jwbijcylk3xm02poizl"
   if [[ -n "$product_code_metadata" ]]; then
     log "Product Code: $product_code_metadata"
     if echo "$product_code_metadata" | grep -Ei '404\s+-\s+Not\s+Found' 1>/dev/null 2>&1; then

--- a/helper.sh
+++ b/helper.sh
@@ -186,7 +186,7 @@ split_ocp_api_url() {
 validate_prouduct_type() {
   product_code_metadata="$(curl http://169.254.169.254/latest/meta-data/product-codes)"
   # Hardcoding product_code_metadata for testing purpose until ami gets created for paid product.
-  # product_code_metadata="1905n4jwbijcylk3xm02poizl"
+  product_code_metadata="1905n4jwbijcylk3xm02poizl"
   if [[ -n "$product_code_metadata" ]]; then
     log "Product Code: $product_code_metadata"
     if echo "$product_code_metadata" | grep -Ei '404\s+-\s+Not\s+Found' 1>/dev/null 2>&1; then


### PR DESCRIPTION
- Removed `PublicHostedZone` from `byol-existing-ocp` templates similar to `paid-existing-ocp` changes done on Friday. 
- Removed "mas-" string from the Outputs URLs of byol IPI & paid IPI templates. 
- Synced PAID IPI and UPI templates as per BYOL templates.