### PR TITLE
Fixed variable name

### DIFF
--- a/pre-validate.sh
+++ b/pre-validate.sh
@@ -14,7 +14,7 @@ found=false
 sentence=${SUPPORTED_REGIONS//;/$'\n'}
 for reg in $sentence
 do
-  if [[ $REGION == $reg ]]; then
+  if [[ $DEPLOY_REGION == $reg ]]; then
     found=true
 	break
   fi


### PR DESCRIPTION
Observed following issue message for supported region "ap-southeast-1" for AWS. 
STATUS_MSG="This region is not supported for MAS deployment."