### PR TITLE
fixed MAS_INSTANCE_ID variable naming

### DIFF
--- a/aws/deploy-cp4d.sh
+++ b/aws/deploy-cp4d.sh
@@ -145,7 +145,7 @@ fi
 
 echoBlue "\n==== Execution started at `date` ===="
 
-export MAS_INSTANCE_ID="mas-${UNIQ_STR}"
+export MAS_INSTANCE_ID="${UNIQ_STR}"
 export MAS_WORKSPACE_ID="wsmasocp"
 
 # CP4D variables

--- a/azure/deploy-cp4d.sh
+++ b/azure/deploy-cp4d.sh
@@ -146,7 +146,7 @@ fi
 
 echoBlue "\n==== Execution started at $(date) ===="
 
-export MAS_INSTANCE_ID="mas-${UNIQ_STR}"
+export MAS_INSTANCE_ID="${UNIQ_STR}"
 export MAS_WORKSPACE_ID="wsmasocp"
 export MAS_WORKSPACE_NAME="wsmasocp"
 export MAS_CONFIG_SCOPE="wsapp"


### PR DESCRIPTION
CP4D deployment failed as mas-core namespace had different name.

Updated the naming convention in **deploy-cp4d.sh** by removing **mas-**.

export MAS_INSTANCE_ID="~~mas-~~${UNIQ_STR}"