### PR TITLE
[456] Modified pre-req check to support OCP v4.8 and v4.10

### DIFF
--- a/script-functions.bash
+++ b/script-functions.bash
@@ -8,7 +8,8 @@ declare -A op_versions
 op_versions['MongoDBCommunity']=4.1.9
 op_versions['Db2uCluster']=11.4
 op_versions['kafkas.kafka.strimzi.io']=2.4.9
-op_versions['ocpVersion']='^4\.([8]?)?(\.[0-9]+.*)*$'
+op_versions['ocpVersion48']='^4\.([8])(\.[0-9]+.*)*$'
+op_versions['ocpVersion410']='^4\.([1][0])?(\.[0-9]+.*)*$'
 op_versions['rosaVersion']='^4\.([1][0])?(\.[0-9]+.*)*$'
 op_versions['cpd-platform-operator']=2.0.7
 op_versions['user-data-services-operator']=2.0.6
@@ -39,8 +40,8 @@ checkROSA(){
 		if [[ $currentOpenshiftVersion =~ ${op_versions[rosaVersion]} ]]; then
     		log " ROSA Cluster Supported Version"
   		else
-    		log " Unsupported ROSA version $currentOpenshiftVersion. Supported ROSA version is 4.10"
-			export SERVICE_NAME=" Unsupported ROSA version $currentOpenshiftVersion. Supported ROSA version is 4.10"
+    		log " Unsupported ROSA version $currentOpenshiftVersion. Supported ROSA version is 4.10.x"
+			export SERVICE_NAME=" Unsupported ROSA version $currentOpenshiftVersion. Supported ROSA version is 4.10.x"
 			SCRIPT_STATUS=29
 			return $SCRIPT_STATUS
  		fi
@@ -55,14 +56,22 @@ checkROSA(){
 }
 
 function getOCPVersion() {
-	#ocpVersion="^4\\.([8-9]|([1-9][0-9])?)?(\\.[0-9]+.*)*$"
 	currentOpenshiftVersion=$(oc get clusterversion | awk  'NR==2 {print $2 }')
 	log " OCP version is $currentOpenshiftVersion"
-	if [[ ${currentOpenshiftVersion} =~ ${op_versions[ocpVersion]} ]]; then
+	if [[ ${currentOpenshiftVersion} =~ ${op_versions[ocpVersion48]} ]]; then
     	log " OCP Supported Version"
+	elif [[ ${currentOpenshiftVersion} =~ ${op_versions[ocpVersion410]} ]]; then
+		log " OCP Supported Version"
+		log " DEPLOY_CP4D: $DEPLOY_CP4D"
+		if [[ $DEPLOY_CP4D == "true" ]]; then
+			SCRIPT_STATUS=29
+			export SERVICE_NAME=" MAS+CP4D offering is not supported on OCP 4.10.x"
+			return $SCRIPT_STATUS
+		fi
+
   	else
-    	log " Unsupported Openshift version $currentOpenshiftVersion.Supported OpenShift version is 4.8"
-		export SERVICE_NAME=" Unsupported Openshift version $currentOpenshiftVersion.Supported OpenShift version is 4.8"
+    	log " Unsupported Openshift version $currentOpenshiftVersion. Supported OpenShift versions are 4.8.x and 4.10.x"
+		export SERVICE_NAME=" Unsupported Openshift version $currentOpenshiftVersion. Supported OpenShift versions are 4.8.x and 4.10.x"
 		SCRIPT_STATUS=29
 		return $SCRIPT_STATUS
  	fi


### PR DESCRIPTION
- Added pre-req check to support OCP v4.8 and v4.10 in case of self managed OCP and only 4.10 for ROSA.
- OCP 4.10 (ROSA and self-managed) should only support MAS Core + Manage offering type.