### PR TITLE
[patch] update env name in invocation due to recent change in ansible parameter name

### DIFF
--- a/aws/deploy.sh
+++ b/aws/deploy.sh
@@ -304,7 +304,7 @@ export AWS_REGION=$DEPLOY_REGION
 log "==== MONGO_USE_EXISTING_INSTANCE = ${MONGO_USE_EXISTING_INSTANCE}"
 if [[ $MONGO_USE_EXISTING_INSTANCE == "true" ]]; then
   if [[ $MONGO_FLAVOR == "Amazon DocumentDB" ]]; then
-    export DB_PROVIDER="aws"
+    export MONGODB_PROVIDER="aws"
     # setting to false, used be sls role
     export SLS_MONGO_RETRYWRITES=false
     log "==== aws/deploy.sh : Invoke docdb-create-vpc-peer.sh starts ===="

--- a/mongo/pre-validate-mongo.sh
+++ b/mongo/pre-validate-mongo.sh
@@ -12,13 +12,13 @@ if [[ $CLUSTER_TYPE == "aws" ]]; then
 
     if [[ $MONGO_FLAVOR == "MongoDB" ]]; then
         export RETRY_WRITES="true";
-        export DB_PROVIDER="community";
+        export MONGODB_PROVIDER="community";
     elif [[ $MONGO_FLAVOR == "Amazon DocumentDB" ]]; then
         export RETRY_WRITES="false";
-        export DB_PROVIDER="aws";
+        export MONGODB_PROVIDER="aws";
     fi
     log "MONGODB RETRY_WRITES=${RETRY_WRITES}"
-    log "MONGODB DB_PROVIDER=${DB_PROVIDER}"
+    log "MONGODB DB_PROVIDER=${MONGODB_PROVIDER}"
 
     log "==== BOOTNODE_VPC_ID = ${BOOTNODE_VPC_ID}"
     log "==== EXISTING_NETWORK = ${EXISTING_NETWORK}"


### PR DESCRIPTION
- Noticed in PR# [748](https://github.com/ibm-mas/ansible-devops/pull/748), environment variable name got updated from `DB_PROVIDER` to `MONGODB_PROVIDER`. [here](https://github.com/ibm-mas/ansible-devops/blob/d99dbb054d947d05ba8edc080c16750502224758/ibm/mas_devops/roles/mongodb/defaults/main.yml#L3)
- Creating this PR to accommodate the above change in `multicloud-bootstrap`