### PR TITLE
[patch] update env name in invocation due to recent change in ansible…

### DIFF
--- a/aws/deploy.sh
+++ b/aws/deploy.sh
@@ -329,7 +329,7 @@ else
   log "==== MongoDB deployment started ==== MONGO_FLAVOR=$MONGO_FLAVOR"
   if [[ $MONGO_FLAVOR == "Amazon DocumentDB" ]]; then
     log "Provision new instance of Amazon Document DB @ VPC_ID=$VPC_ID"
-    export DB_PROVIDER="aws"
+    export MONGODB_PROVIDER="aws"
     # setting to false, used be sls role
     export SLS_MONGO_RETRYWRITES=false
     #by default its create (provision) action in mongo role.


### PR DESCRIPTION

- Noticed in PR# [748](https://github.com/ibm-mas/ansible-devops/pull/748), environment variable name got updated from `DB_PROVIDER` to `MONGODB_PROVIDER`. [here](https://github.com/ibm-mas/ansible-devops/blob/d99dbb054d947d05ba8edc080c16750502224758/ibm/mas_devops/roles/mongodb/defaults/main.yml#L3)
- Creating this PR to accommodate the above change in `multicloud-bootstrap`