### PR TITLE
Checking in code for database on private subnet of diff VPC

### DIFF
--- a/aws/db/db-create-iam-user.sh
+++ b/aws/db/db-create-iam-user.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+SCRIPT_STATUS=0
+if [[ -f "/tmp/iam-user-created" ]]; then
+    log "aws/db/db-create-iam-user.sh : /tmp/iam-user-created exists; db-create-iam-user.sh skipped ..."
+else
+    log "aws/db/db-create-iam-user.sh : /tmp/iam-user-created not exists"
+    log "aws/db/db-create-iam-user.sh: .......... starts"
+    # IAM variables
+    IAM_POLICY_NAME="masocp-policy-${RANDOM_STR}"
+    IAM_USER_NAME="masocp-user-${RANDOM_STR}"
+    ## IAM # Create IAM policy
+    cd $GIT_REPO_HOME/aws
+    policyarn=$(aws iam create-policy --policy-name ${IAM_POLICY_NAME} --policy-document file://${GIT_REPO_HOME}/aws/iam/policy.json | jq '.Policy.Arn' | tr -d "\"")
+    # Create IAM user
+    aws iam create-user --user-name ${IAM_USER_NAME}
+    aws iam attach-user-policy --user-name ${IAM_USER_NAME} --policy-arn $policyarn
+
+    if [ $? -ne 0 ]; then
+        SCRIPT_STATUS=36
+    fi
+    accessdetails=$(aws iam create-access-key --user-name ${IAM_USER_NAME})
+    export AWS_ACCESS_KEY_ID=$(echo $accessdetails | jq '.AccessKey.AccessKeyId' | tr -d "\"")
+    export AWS_SECRET_ACCESS_KEY=$(echo $accessdetails | jq '.AccessKey.SecretAccessKey' | tr -d "\"")
+
+    aws configure set aws_access_key_id $AWS_ACCESS_KEY_ID
+    aws configure set aws_secret_access_key $AWS_SECRET_ACCESS_KEY
+    aws configure set default.region $DEPLOY_REGION
+
+    if [ $? -ne 0 ]; then
+        SCRIPT_STATUS=36
+    fi
+    log "aws/db/db-create-iam-user.sh: .......... AWS_ACCESS_KEY_ID:DEPLOY_REGION $AWS_ACCESS_KEY_ID : $DEPLOY_REGION"
+    # on successful completion of db-create-iam-user.sh, create a file
+    echo "COMPLETE" > /tmp/iam-user-created
+    chmod a+rw /tmp/iam-user-created
+    # Put some delay for IAM permissions to be applied in the backend
+    sleep 60
+    log "aws/db/db-create-iam-user.sh: .......... ends"
+
+fi
+
+

--- a/aws/db/db-create-vpc-peer.sh
+++ b/aws/db/db-create-vpc-peer.sh
@@ -1,0 +1,199 @@
+#!/bin/bash
+	export VPC_1=$REQUESTER_VPC_ID
+    export VPC_2=$ACCEPTER_VPC_ID
+	export ACCEPTER_REGION=$DEPLOY_REGION
+
+    log "db-create-vpc-peer.sh .......... starts"
+    log "db-create-vpc-peer.sh : REQUESTER_VPC_ID : $REQUESTER_VPC_ID" #BOOTNODE_VPC_ID or VPC_ID
+    log "db-create-vpc-peer.sh : ACCEPTER_VPC_ID : $ACCEPTER_VPC_ID" #db_VPC_ID
+	log "db-create-vpc-peer.sh : ACCEPTER_REGION : $ACCEPTER_REGION"
+    if [[ "${VPC_1}" != "${VPC_2}" ]]; then
+
+        log "db-create-vpc-peer.sh : Invoke db-create-iam-user.sh"
+
+		sh $GIT_REPO_HOME/aws/db/db-create-iam-user.sh
+		if [ $? -ne 0 ]; then
+			SCRIPT_STATUS=36
+			exit $SCRIPT_STATUS
+		fi
+
+ 		export _VPC_1=`aws ec2 describe-vpcs --filters "Name=vpc-id,Values=$VPC_1" --region $ACCEPTER_REGION --query=Vpcs[*].VpcId --output=text`
+		export _VPC_2=`aws ec2 describe-vpcs --filters "Name=vpc-id,Values=$VPC_2" --region $ACCEPTER_REGION --query=Vpcs[*].VpcId --output=text`
+		log "_VPC_1=$_VPC_1"
+		log "_VPC_2=$_VPC_2"
+
+		if [[ -z "$_VPC_2" ]]; then
+			SCRIPT_STATUS="45"
+			log "db-create-vpc-peer.sh : User entered $_VPC_2 is not found in region $ACCEPTER_REGION, exiting..."
+			exit $SCRIPT_STATUS
+		fi
+
+		#This edge case will not occur as BOOTNODE_VPC_ID or VPC_ID will be there.
+		if [[ -z "$_VPC_1" ]]; then
+			SCRIPT_STATUS="40"
+			log "db-create-vpc-peer.sh : $_VPC_1 is not found in region $ACCEPTER_REGION, exiting..."
+			exit $SCRIPT_STATUS
+		fi
+
+		export VPC_1_CIDR=`aws ec2 describe-vpcs --filters "Name=vpc-id,Values=$VPC_1" --region $ACCEPTER_REGION --query=Vpcs[*].CidrBlock --output=text`
+		export VPC_2_CIDR=`aws ec2 describe-vpcs --filters "Name=vpc-id,Values=$VPC_2" --region $ACCEPTER_REGION --query=Vpcs[*].CidrBlock --output=text`
+		log "VPC_1_CIDR=$VPC_1_CIDR"
+		log "VPC_2_CIDR=$VPC_2_CIDR"
+
+		if [[ -z "$VPC_1_CIDR" || -z "$VPC_2_CIDR" ]]; then
+			SCRIPT_STATUS=35
+			log "db-create-vpc-peer.sh : VPC_1_CIDR or VPC_2_CIDR is empty, exiting..."
+			exit $SCRIPT_STATUS
+		fi
+
+        log "db-create-vpc-peer.sh : Invoke create-vpc-peering-connection"
+        export VPC_PEERING_CONNECTION_ID=`aws ec2 create-vpc-peering-connection --vpc-id ${VPC_1} --peer-vpc-id ${VPC_2} --query="VpcPeeringConnection.VpcPeeringConnectionId" --output text`
+        sleep 30
+        log "db-create-vpc-peer.sh : VPC_PEERING_CONNECTION_ID=$VPC_PEERING_CONNECTION_ID"
+        if [[ -z "$VPC_PEERING_CONNECTION_ID" ]]; then
+            SCRIPT_STATUS=35
+            log "db-create-vpc-peer.sh : VPC_PEERING_CONNECTION_ID is empty, exiting..."
+			exit $SCRIPT_STATUS
+        fi
+        if [[ -n "$VPC_PEERING_CONNECTION_ID" ]]; then
+            log "db-create-vpc-peer.sh : aws ec2 accept-vpc-peering-connection"
+
+			counter=0
+			found="false"
+			while [[ $found == "false" ]] && [[ $counter < 20 ]]; do
+				counter=counter+1
+				aws ec2 accept-vpc-peering-connection --vpc-peering-connection-id ${VPC_PEERING_CONNECTION_ID} --query="VpcPeeringConnection.Status.Code"
+				if [[ $? -ne 0 ]]; then
+					SCRIPT_STATUS=35
+					log "db-create-vpc-peer.sh : ACCEPT_VPC_PEERING_CONNECTION failed, exiting..."
+					exit $SCRIPT_STATUS
+				else
+					log "db-create-vpc-peer.sh : ACCEPT_VPC_PEERING_CONNECTION accepted, waiting for provisioning and status change to active..."
+					sleep 60
+					export ACCEPT_VPC_PEERING_CONNECTION=`aws ec2 accept-vpc-peering-connection --vpc-peering-connection-id ${VPC_PEERING_CONNECTION_ID} --query="VpcPeeringConnection.Status.Code"`
+					log "db-create-vpc-peer.sh : ACCEPT_VPC_PEERING_CONNECTION==$ACCEPT_VPC_PEERING_CONNECTION"
+					if [[ "${ACCEPT_VPC_PEERING_CONNECTION}" == *"active"* ]] ;then
+						found="true"
+					fi
+				fi
+			done
+
+			log "db-create-vpc-peer.sh : ACCEPT_VPC_PEERING_CONNECTION=$ACCEPT_VPC_PEERING_CONNECTION"
+			if [[ -z "$ACCEPT_VPC_PEERING_CONNECTION"  ]]; then
+				SCRIPT_STATUS=35
+				log "db-create-vpc-peer.sh : ACCEPT_VPC_PEERING_CONNECTION is empty, exiting..."
+				exit $SCRIPT_STATUS
+			fi
+
+			# Creating Routes for vpc peering at cluster and mirror machines
+			log "db-create-vpc-peer.sh : create routes started"
+
+			# Get main Route table id for each vpc id
+			if [[ -n "$VPC_PEERING_CONNECTION_ID" && "${ACCEPT_VPC_PEERING_CONNECTION}" == *"active"* ]] ;then
+				# routing tables
+				log "---------------------------------------------"
+				log "Checking for routing tables for VPC $VPC_1"
+				RTS=$(aws ec2 describe-route-tables --filter Name=vpc-id,Values=$VPC_1 --region $DEPLOY_REGION | jq ".RouteTables[].RouteTableId" | tr -d '"')
+				log "RTS = $RTS"
+				if [[ -n $RTS ]]; then
+					log "Found routing tables for this AWS stack"
+					for VPC_1_ROUTE_TABLE_ID in $RTS; do
+
+						#check if the route with blackhole status exist
+						EXISTING_ROUTE_TABLE_ID_WITH_BLACKHOLE_STATUS=`aws ec2 describe-route-tables --filters  \
+						--region $ACCEPTER_REGION \
+						"Name=route-table-id,Values=$VPC_1_ROUTE_TABLE_ID"  \
+						"Name=route.destination-cidr-block,Values=$VPC_2_CIDR" \
+						"Name=route.state,Values=blackhole" \
+						--query RouteTables[].RouteTableId  --output=text`
+
+						if [[ -n $EXISTING_ROUTE_TABLE_ID_WITH_BLACKHOLE_STATUS ]]; then
+							log "db-create-vpc-peer.sh : aws ec2 delete-route route-table-id $VPC_1_ROUTE_TABLE_ID destination-cidr-block $VPC_2_CIDR started"
+							aws ec2 delete-route --route-table-id $VPC_1_ROUTE_TABLE_ID --destination-cidr-block $VPC_2_CIDR --region $ACCEPTER_REGION
+						fi
+
+						#check if the route exist already
+						EXISTING_ROUTE_TABLE_ID=`aws ec2 describe-route-tables --filters  \
+						--region $ACCEPTER_REGION \
+						"Name=route-table-id,Values=$VPC_1_ROUTE_TABLE_ID"  \
+						"Name=route.vpc-peering-connection-id,Values=$VPC_PEERING_CONNECTION_ID" \
+						"Name=route.destination-cidr-block,Values=$VPC_2_CIDR" \
+						"Name=route.state,Values=active" \
+						--query RouteTables[].RouteTableId  --output=text`
+						log "db-create-vpc-peer.sh : EXISTING_ROUTE_TABLE_ID=$EXISTING_ROUTE_TABLE_ID"
+						if [[ -z $EXISTING_ROUTE_TABLE_ID ]]; then
+							log "db-create-vpc-peer.sh : aws ec2 create-route $VPC_1_ROUTE_TABLE_ID $VPC_2_CIDR $VPC_PEERING_CONNECTION_ID started"
+							export CREATE_ROUTE_1=`aws ec2 create-route --route-table-id $VPC_1_ROUTE_TABLE_ID --destination-cidr-block $VPC_2_CIDR --vpc-peering-connection-id $VPC_PEERING_CONNECTION_ID --output=text`
+							sleep 10
+							log "db-create-vpc-peer.sh : CREATE_ROUTE_1=$CREATE_ROUTE_1"
+							if [[ ("${CREATE_ROUTE_1}" != "True") ]]; then
+								#An error occurred (RouteAlreadyExists) when calling the CreateRoute operation: The route identified by 172.31.0.0/16 already exists.
+								SCRIPT_STATUS=37
+								log "db-create-vpc-peer.sh : aws ec2 create-route CREATE_ROUTE_1 creation failed, exiting..."
+								exit $SCRIPT_STATUS
+							fi
+						fi
+					done
+				else
+					log "No routing tables found for this AWS stack"
+				fi
+				log "---------------------------------------------"
+
+				# routing tables
+				log "Checking for routing tables for VPC $VPC_2"
+				RTS=$(aws ec2 describe-route-tables --filter Name=vpc-id,Values=$VPC_2 --region $DEPLOY_REGION | jq ".RouteTables[].RouteTableId" | tr -d '"')
+				log "RTS = $RTS"
+				if [[ -n $RTS ]]; then
+					log "Found routing tables for this AWS stack"
+					for VPC_2_ROUTE_TABLE_ID in $RTS; do
+						#check if the route with blackhole status exist
+						EXISTING_ROUTE_TABLE_ID_WITH_BLACKHOLE_STATUS=`aws ec2 describe-route-tables --filters  \
+						--region $ACCEPTER_REGION \
+						"Name=route-table-id,Values=$VPC_2_ROUTE_TABLE_ID"  \
+						"Name=route.destination-cidr-block,Values=$VPC_1_CIDR" \
+						"Name=route.state,Values=blackhole" \
+						--query RouteTables[].RouteTableId  --output=text`
+
+						if [[ -n $EXISTING_ROUTE_TABLE_ID_WITH_BLACKHOLE_STATUS ]]; then
+							log "db-create-vpc-peer.sh : aws ec2 delete-route route-table-id $VPC_2_ROUTE_TABLE_ID destination-cidr-block $VPC_1_CIDR started"
+							aws ec2 delete-route --route-table-id $VPC_2_ROUTE_TABLE_ID --destination-cidr-block $VPC_1_CIDR --region $ACCEPTER_REGION
+						fi
+
+						#check if the route exist already for same peer and dest vpc
+						EXISTING_ROUTE_TABLE_ID=`aws ec2 describe-route-tables --filters  \
+						--region $ACCEPTER_REGION \
+						"Name=route-table-id,Values=$VPC_2_ROUTE_TABLE_ID"  \
+						"Name=route.vpc-peering-connection-id,Values=$VPC_PEERING_CONNECTION_ID" \
+						"Name=route.destination-cidr-block,Values=$VPC_1_CIDR" \
+						"Name=route.state,Values=active" \
+						--query RouteTables[].RouteTableId  --output=text`
+
+						log "db-create-vpc-peer.sh : EXISTING_ROUTE_TABLE_ID_2=$EXISTING_ROUTE_TABLE_ID"
+						if [[ -z $EXISTING_ROUTE_TABLE_ID ]]; then
+							log "db-create-vpc-peer.sh : aws ec2 create-route $VPC_2_ROUTE_TABLE_ID $VPC_1_CIDR $VPC_PEERING_CONNECTION_ID started"
+							export CREATE_ROUTE_2=`aws ec2 create-route --route-table-id $VPC_2_ROUTE_TABLE_ID --destination-cidr-block $VPC_1_CIDR --vpc-peering-connection-id $VPC_PEERING_CONNECTION_ID --output=text`
+							sleep 10
+							log "db-create-vpc-peer.sh : CREATE_ROUTE_2=$CREATE_ROUTE_2"
+							if [[ ("${CREATE_ROUTE_2}" != "True") ]]; then
+								SCRIPT_STATUS=37
+								log "db-create-vpc-peer.sh : aws ec2 create-route CREATE_ROUTE_2 creation failed, exiting..."
+								exit $SCRIPT_STATUS
+							fi
+						fi
+
+					done
+				else
+					log "No routing tables found for this AWS stack"
+				fi
+				log "---------------------------------------------"
+
+			else
+				SCRIPT_STATUS=37
+				log "db-create-vpc-peer.sh : route not created, VPC_PEERING_CONNECTION_ID=$VPC_PEERING_CONNECTION_ID : ACCEPT_VPC_PEERING_CONNECTION=$ACCEPT_VPC_PEERING_CONNECTION"
+				exit $SCRIPT_STATUS
+			fi
+			log "db-create-vpc-peer.sh : create routes completed"
+        fi
+    fi
+log "db-create-vpc-peer.sh .......... ends : SCRIPT_STATUS=$SCRIPT_STATUS"
+

--- a/aws/deploy.sh
+++ b/aws/deploy.sh
@@ -308,6 +308,17 @@ if [[ -z $VPC_ID && $MONGO_FLAVOR == "Amazon DocumentDB" ]]; then
 fi
 export AWS_REGION=$DEPLOY_REGION
 
+if [[ -n $DBProvisionedVPCId ]]; then
+cd $GIT_REPO_HOME
+log "==== aws/deploy.sh : Invoke db-create-vpc-peer.sh starts ===="
+    log "Existing instance of db @ VPC_ID=$DBProvisionedVPCId"
+    export ACCEPTER_VPC_ID=${DBProvisionedVPCId}
+    export REQUESTER_VPC_ID=${VPC_ID}
+
+    sh $GIT_REPO_HOME/aws/db/db-create-vpc-peer.sh
+    log "==== aws/deploy.sh : Invoke db-create-vpc-peer.sh ends ===="
+fi
+
 log "==== MONGO_USE_EXISTING_INSTANCE = ${MONGO_USE_EXISTING_INSTANCE}"
 if [[ $MONGO_USE_EXISTING_INSTANCE == "true" ]]; then
   if [[ $MONGO_FLAVOR == "Amazon DocumentDB" ]]; then

--- a/aws/master-cft/byol-existing-ocp/cft-mas-core-dev.yaml
+++ b/aws/master-cft/byol-existing-ocp/cft-mas-core-dev.yaml
@@ -74,6 +74,11 @@ Parameters:
       Enter the HTTP or S3 location of the database's public certificate, for
       example: s3://masocp-license/db-certificate.crt
     Type: String
+  DBProvisionedVPCId:
+    Description: >-
+      Enter the VPC ID where your existing database (DB2 or Oracle or MSSQL) was provisioned on a private subnet to establish 
+      VPC Peering from this VPC & the VPC created during current stack deployment in order to establish database connection.
+    Type: String
   ImportDemoData:
     Description: >-
       Indicate whether you want to import demo data into the database. This
@@ -230,6 +235,7 @@ Metadata:
           - MASManageDBPassword
           - MASManageDBJdbcUrl
           - MASManageDBCertificateUrl
+          - DBProvisionedVPCId
           - ImportDemoData
       - Label:
           default: MongoDB Configuration
@@ -709,6 +715,8 @@ Resources:
             - !If [MongoUseExistingInstanceCondition, !Ref DocumentDBProvisionedVPCId, ""]
             - ''' '''
             - !Ref AWSMSKProvider
+            - ''' '''
+            - !Ref DBProvisionedVPCId
             - ''' "dev" '
             - '2>&1 | tee mas-provisioning.log; '
       Tags:

--- a/aws/master-cft/byol-existing-ocp/cft-mas-core.yaml
+++ b/aws/master-cft/byol-existing-ocp/cft-mas-core.yaml
@@ -74,6 +74,11 @@ Parameters:
       Enter the HTTP or S3 location of the database's public certificate, for
       example: s3://masocp-license/db-certificate.crt
     Type: String
+  DBProvisionedVPCId:
+    Description: >-
+      Enter the VPC ID where your existing database (DB2 or Oracle or MSSQL) was provisioned on a private subnet to establish 
+      VPC Peering from this VPC & the VPC created during current stack deployment in order to establish database connection.
+    Type: String
   ImportDemoData:
     Description: >-
       Indicate whether you want to import demo data into the database. This
@@ -230,6 +235,7 @@ Metadata:
           - MASManageDBPassword
           - MASManageDBJdbcUrl
           - MASManageDBCertificateUrl
+          - DBProvisionedVPCId
           - ImportDemoData
       - Label:
           default: MongoDB Configuration
@@ -712,6 +718,8 @@ Resources:
             - !If [MongoUseExistingInstanceCondition, !Ref DocumentDBProvisionedVPCId, ""]
             - ''' '''
             - !Ref AWSMSKProvider
+            - ''' '''
+            - !Ref DBProvisionedVPCId
             - ''' "prod" '
             - '2>&1 | tee mas-provisioning.log; '
       Tags:

--- a/aws/master-cft/byol-ipi/cft-mas-core-dev.yaml
+++ b/aws/master-cft/byol-ipi/cft-mas-core-dev.yaml
@@ -79,6 +79,11 @@ Parameters:
       Enter the HTTP or S3 location of the database's public certificate, for
       example: s3://masocp-license/db-certificate.crt
     Type: String
+  DBProvisionedVPCId:
+    Description: >-
+      Enter the VPC ID where your existing database (DB2 or Oracle or MSSQL) was provisioned on a private subnet to establish 
+      VPC Peering from this VPC & the VPC created during current stack deployment in order to establish database connection.
+    Type: String
   ImportDemoData:
     Description: >-
       Indicate whether you want to import demo data into the database. This
@@ -236,6 +241,7 @@ Metadata:
           - MASManageDBPassword
           - MASManageDBJdbcUrl
           - MASManageDBCertificateUrl
+          - DBProvisionedVPCId
           - ImportDemoData
       - Label:
           default: MongoDB Configuration
@@ -283,45 +289,49 @@ Metadata:
 Mappings:
   RegionMap:
     us-east-1:
-      HVM64: ami-0645cfae3e3b8078b
+      HVM64: ami-07809a17acfe15035
     us-east-2:
-      HVM64: ami-0da4f91ded4bac1bd
+      HVM64: ami-xxxxxxxxxxxxxxxxx
     us-west-2:
-      HVM64: ami-0d6ac2d0246b8f646
-    ap-east-1:
-      HVM64: ami-05b4d16ec6412d429
-    ap-southeast-1:
-      HVM64: ami-0e084c2cc29ec1720
-    ap-southeast-2:
-      HVM64: ami-093254aff333dcfe3
-    ap-northeast-1:
-      HVM64: ami-0786a7bec0e143591
-    eu-central-1:
-      HVM64: ami-09fbeb232efd55c04
-    ap-south-1:
-      HVM64: ami-09ee06d85c3bf30f9
-    ap-northeast-2:
-      HVM64: ami-0b5a78be9ec85d01b
-    ap-northeast-3:
-      HVM64: ami-0d96abb825f3fc970
+      HVM64: ami-xxxxxxxxxxxxxxxxx
     ca-central-1:
-      HVM64: ami-05de5e08f0f2ebd49
-    eu-south-1:
-      HVM64: ami-045e0d5842edd2162
-    eu-west-1:
-      HVM64: ami-0eead16d37ab73f41
-    eu-west-2:
-      HVM64: ami-0b91a33eb29e0b111
-    eu-west-3:
-      HVM64: ami-07701973de476bf5c
+      HVM64: ami-xxxxxxxxxxxxxxxxx
     eu-north-1:
-      HVM64: ami-0a58f0bb290790019
-    af-south-1:
-      HVM64: ami-051f9c6d45b88f721
-    me-south-1:
-      HVM64: ami-0872ea1a62d5925b8
+      HVM64: ami-xxxxxxxxxxxxxxxxx
+    eu-west-1:
+      HVM64: ami-xxxxxxxxxxxxxxxxx
+    eu-west-2:
+      HVM64: ami-xxxxxxxxxxxxxxxxx
+    eu-west-3:
+      HVM64: ami-xxxxxxxxxxxxxxxxx
+    eu-central-1:
+      HVM64: ami-xxxxxxxxxxxxxxxxx
+    ap-northeast-1:
+      HVM64: ami-xxxxxxxxxxxxxxxxx
+    ap-northeast-2:
+      HVM64: ami-xxxxxxxxxxxxxxxxx
+    ap-northeast-3:
+      HVM64: ami-xxxxxxxxxxxxxxxxx
+    ap-south-1:
+      HVM64: ami-xxxxxxxxxxxxxxxxx
+    ap-southeast-1:
+      HVM64: ami-xxxxxxxxxxxxxxxxx
+    ap-southeast-2:
+      HVM64: ami-xxxxxxxxxxxxxxxxx
     sa-east-1:
-      HVM64: ami-02db20519b43317bb
+      HVM64: ami-xxxxxxxxxxxxxxxxx
+    af-south-1:
+      HVM64: ami-xxxxxxxxxxxxxxxxx
+    ap-east-1:
+      HVM64: ami-xxxxxxxxxxxxxxxxx
+    ap-southeast-3:
+      HVM64: ami-xxxxxxxxxxxxxxxxx
+    eu-south-1:
+      HVM64: ami-xxxxxxxxxxxxxxxxx
+    me-south-1:
+      HVM64: ami-xxxxxxxxxxxxxxxxx
+    me-central-1:
+      HVM64: ami-xxxxxxxxxxxxxxxxx
 Resources:
   DeployWaitConditionHandle:
     Type: 'AWS::CloudFormation::WaitConditionHandle'
@@ -648,7 +658,7 @@ Resources:
             - 'git clone https://github.com/ibm-mas/ansible-devops.git;'
             - cd ansible-devops;
             - rm -rf multicloud-bootstrap 1>/dev/null 2>&1;
-            - 'git clone  https://github.com/ibm-mas/multicloud-bootstrap.git;'
+            - 'git clone -b mas810-alpha https://github.com/ibm-mas/multicloud-bootstrap.git;'
             - cd multicloud-bootstrap;
             - 'find . -type f -name "*.sh" -exec chmod +x {} \;;'
             - ./init.sh "aws" "
@@ -725,7 +735,9 @@ Resources:
             - ''' '''
             - !If [MongoUseExistingInstanceCondition, !Ref DocumentDBProvisionedVPCId, ""]
             - ''' '''
-            - !Ref AWSMSKProvider	    
+            - !Ref AWSMSKProvider
+            - ''' '''
+            - !Ref DBProvisionedVPCId
             - ''' "dev" '
             - '2>&1 | tee mas-provisioning.log; '
       Tags:

--- a/aws/master-cft/byol-ipi/cft-mas-core.yaml
+++ b/aws/master-cft/byol-ipi/cft-mas-core.yaml
@@ -79,6 +79,11 @@ Parameters:
       Enter the HTTP or S3 location of the database's public certificate, for
       example: s3://masocp-license/db-certificate.crt
     Type: String
+  DBProvisionedVPCId:
+    Description: >-
+      Enter the VPC ID where your existing database (DB2 or Oracle or MSSQL) was provisioned on a private subnet to establish 
+      VPC Peering from this VPC & the VPC created during current stack deployment in order to establish database connection.
+    Type: String
   ImportDemoData:
     Description: >-
       Indicate whether you want to import demo data into the database. This
@@ -236,6 +241,7 @@ Metadata:
           - MASManageDBPassword
           - MASManageDBJdbcUrl
           - MASManageDBCertificateUrl
+          - DBProvisionedVPCId
           - ImportDemoData
       - Label:
           default: MongoDB Configuration
@@ -730,6 +736,8 @@ Resources:
             - !If [MongoUseExistingInstanceCondition, !Ref DocumentDBProvisionedVPCId, ""]
             - ''' '''
             - !Ref AWSMSKProvider
+            - ''' '''
+            - !Ref DBProvisionedVPCId
             - ''' "prod" '
             - '2>&1 | tee mas-provisioning.log; '
       Tags:

--- a/aws/master-cft/byol-upi/cft-mas-core-dev.yaml
+++ b/aws/master-cft/byol-upi/cft-mas-core-dev.yaml
@@ -114,6 +114,11 @@ Parameters:
       Enter the HTTP or S3 location of the database's public certificate, for
       example: s3://masocp-license/db-certificate.crt
     Type: String
+  DBProvisionedVPCId:
+    Description: >-
+      Enter the VPC ID where your existing database (DB2 or Oracle or MSSQL) was provisioned on a private subnet to establish 
+      VPC Peering from this VPC & the VPC created during current stack deployment in order to establish database connection.
+    Type: String
   ImportDemoData:
     Description: >-
       Indicate whether you want to import demo data into the database. This
@@ -278,6 +283,7 @@ Metadata:
           - MASManageDBPassword
           - MASManageDBJdbcUrl
           - MASManageDBCertificateUrl
+          - DBProvisionedVPCId
           - ImportDemoData
       - Label:
           default: MongoDB Configuration
@@ -740,7 +746,9 @@ Resources:
             - ''' '''
             - !If [MongoUseExistingInstanceCondition, !Ref DocumentDBProvisionedVPCId, ""]
             - ''' '''
-            - !Ref AWSMSKProvider	    
+            - !Ref AWSMSKProvider
+            - ''' '''
+            - !Ref DBProvisionedVPCId
             - ''' "dev" '
             - '2>&1 | tee mas-provisioning.log; '
       Tags:

--- a/aws/master-cft/byol-upi/cft-mas-core.yaml
+++ b/aws/master-cft/byol-upi/cft-mas-core.yaml
@@ -112,6 +112,11 @@ Parameters:
       Enter the HTTP or S3 location of the database's public certificate, for
       example: s3://masocp-license/db-certificate.crt
     Type: String
+  DBProvisionedVPCId:
+    Description: >-
+      Enter the VPC ID where your existing database (DB2 or Oracle or MSSQL) was provisioned on a private subnet to establish 
+      VPC Peering from this VPC & the VPC created during current stack deployment in order to establish database connection.
+    Type: String
   ImportDemoData:
     Description: >-
       Indicate whether you want to import demo data into the database. This
@@ -276,6 +281,7 @@ Metadata:
           - MASManageDBPassword
           - MASManageDBJdbcUrl
           - MASManageDBCertificateUrl
+          - DBProvisionedVPCId
           - ImportDemoData
       - Label:
           default: MongoDB Configuration
@@ -743,6 +749,8 @@ Resources:
             - !If [MongoUseExistingInstanceCondition, !Ref DocumentDBProvisionedVPCId, ""]
             - ''' '''
             - !Ref AWSMSKProvider
+            - ''' '''
+            - !Ref DBProvisionedVPCId
             - ''' "prod" '
             - '2>&1 | tee mas-provisioning.log; '
       Tags:

--- a/aws/master-cft/paid-existing-ocp/cft-mas-core-dev.yaml
+++ b/aws/master-cft/paid-existing-ocp/cft-mas-core-dev.yaml
@@ -68,6 +68,11 @@ Parameters:
       Enter the HTTP or S3 location of the database's public certificate, for
       example: s3://masocp-license/db-certificate.crt
     Type: String
+  DBProvisionedVPCId:
+    Description: >-
+      Enter the VPC ID where your existing database (DB2 or Oracle or MSSQL) was provisioned on a private subnet to establish 
+      VPC Peering from this VPC & the VPC created during current stack deployment in order to establish database connection.
+    Type: String
   ImportDemoData:
     Description: >-
       Indicate whether you want to import demo data into the database. This
@@ -223,6 +228,7 @@ Metadata:
           - MASManageDBPassword
           - MASManageDBJdbcUrl
           - MASManageDBCertificateUrl
+          - DBProvisionedVPCId
           - ImportDemoData
       - Label:
           default: MongoDB Configuration
@@ -700,6 +706,8 @@ Resources:
             - !If [MongoUseExistingInstanceCondition, !Ref DocumentDBProvisionedVPCId, ""]
             - ''' '''
             - !Ref AWSMSKProvider
+            - ''' '''
+            - !Ref DBProvisionedVPCId
             - ''' "dev" '
             - '2>&1 | tee mas-provisioning.log; '
       Tags:

--- a/aws/master-cft/paid-existing-ocp/cft-mas-core.yaml
+++ b/aws/master-cft/paid-existing-ocp/cft-mas-core.yaml
@@ -68,6 +68,11 @@ Parameters:
       Enter the HTTP or S3 location of the database's public certificate, for
       example: s3://masocp-license/db-certificate.crt
     Type: String
+  DBProvisionedVPCId:
+    Description: >-
+      Enter the VPC ID where your existing database (DB2 or Oracle or MSSQL) was provisioned on a private subnet to establish 
+      VPC Peering from this VPC & the VPC created during current stack deployment in order to establish database connection.
+    Type: String
   ImportDemoData:
     Description: >-
       Indicate whether you want to import demo data into the database. This
@@ -223,6 +228,7 @@ Metadata:
           - MASManageDBPassword
           - MASManageDBJdbcUrl
           - MASManageDBCertificateUrl
+          - DBProvisionedVPCId
           - ImportDemoData
       - Label:
           default: MongoDB Configuration
@@ -691,6 +697,8 @@ Resources:
             - !If [MongoUseExistingInstanceCondition, !Ref DocumentDBProvisionedVPCId, ""]
             - ''' '''
             - !Ref AWSMSKProvider
+            - ''' '''
+            - !Ref DBProvisionedVPCId
             - ''' "prod" '
             - '2>&1 | tee mas-provisioning.log; '
       Tags:

--- a/aws/master-cft/paid-ipi/cft-mas-core-dev.yaml
+++ b/aws/master-cft/paid-ipi/cft-mas-core-dev.yaml
@@ -71,6 +71,11 @@ Parameters:
       Enter the HTTP or S3 location of the database's public certificate, for
       example: s3://masocp-license/db-certificate.crt
     Type: String
+  DBProvisionedVPCId:
+    Description: >-
+      Enter the VPC ID where your existing database (DB2 or Oracle or MSSQL) was provisioned on a private subnet to establish 
+      VPC Peering from this VPC & the VPC created during current stack deployment in order to establish database connection.
+    Type: String 
   ImportDemoData:
     Description: >-
       Indicate whether you want to import demo data into the database. This
@@ -224,6 +229,7 @@ Metadata:
           - MASManageDBPassword
           - MASManageDBJdbcUrl
           - MASManageDBCertificateUrl
+          - DBProvisionedVPCId
           - ImportDemoData
       - Label:
           default: MongoDB Configuration
@@ -712,7 +718,9 @@ Resources:
             - ''' '''
             - !If [MongoUseExistingInstanceCondition, !Ref DocumentDBProvisionedVPCId, ""]
             - ''' '''
-            - !Ref AWSMSKProvider	    
+            - !Ref AWSMSKProvider
+            - ''' '''
+            - !Ref DBProvisionedVPCId
             - ''' "dev" '
             - '2>&1 | tee mas-provisioning.log; '
       Tags:

--- a/aws/master-cft/paid-ipi/cft-mas-core-without-ocp-license.yaml
+++ b/aws/master-cft/paid-ipi/cft-mas-core-without-ocp-license.yaml
@@ -80,6 +80,11 @@ Parameters:
       Enter the HTTP or S3 location of the database's public certificate, for
       example: s3://masocp-license/db-certificate.crt
     Type: String
+  DBProvisionedVPCId:
+    Description: >-
+      Enter the VPC ID where your existing database (DB2 or Oracle or MSSQL) was provisioned on a private subnet to establish 
+      VPC Peering from this VPC & the VPC created during current stack deployment in order to establish database connection.
+    Type: String
   ImportDemoData:
     Description: >-
       Indicate whether you want to import demo data into the database. This
@@ -234,6 +239,7 @@ Metadata:
           - MASManageDBPassword
           - MASManageDBJdbcUrl
           - MASManageDBCertificateUrl
+          - DBProvisionedVPCId
           - ImportDemoData
       - Label:
           default: MongoDB Configuration
@@ -714,6 +720,8 @@ Resources:
             - !If [MongoUseExistingInstanceCondition, !Ref DocumentDBProvisionedVPCId, ""]
             - ''' '''
             - !Ref AWSMSKProvider
+            - ''' '''
+            - !Ref DBProvisionedVPCId
             - ''' "prod" '
             - '2>&1 | tee mas-provisioning.log; '
       Tags:

--- a/aws/master-cft/paid-ipi/cft-mas-core.yaml
+++ b/aws/master-cft/paid-ipi/cft-mas-core.yaml
@@ -71,6 +71,11 @@ Parameters:
       Enter the HTTP or S3 location of the database's public certificate, for
       example: s3://masocp-license/db-certificate.crt
     Type: String
+  DBProvisionedVPCId:
+    Description: >-
+      Enter the VPC ID where your existing database (DB2 or Oracle or MSSQL) was provisioned on a private subnet to establish 
+      VPC Peering from this VPC & the VPC created during current stack deployment in order to establish database connection.
+    Type: String
   ImportDemoData:
     Description: >-
       Indicate whether you want to import demo data into the database. This
@@ -224,6 +229,7 @@ Metadata:
           - MASManageDBPassword
           - MASManageDBJdbcUrl
           - MASManageDBCertificateUrl
+          - DBProvisionedVPCId
           - ImportDemoData
       - Label:
           default: MongoDB Configuration
@@ -704,6 +710,8 @@ Resources:
             - !If [MongoUseExistingInstanceCondition, !Ref DocumentDBProvisionedVPCId, ""]
             - ''' '''
             - !Ref AWSMSKProvider
+            - ''' '''
+            - !Ref DBProvisionedVPCId
             - ''' "prod" '
             - '2>&1 | tee mas-provisioning.log; '
       Tags:

--- a/aws/master-cft/paid-upi/cft-mas-core-dev.yaml
+++ b/aws/master-cft/paid-upi/cft-mas-core-dev.yaml
@@ -106,6 +106,11 @@ Parameters:
       Enter the HTTP or S3 location of the database's public certificate, for
       example: s3://masocp-license/db-certificate.crt
     Type: String
+  DBProvisionedVPCId:
+    Description: >-
+      Enter the VPC ID where your existing database (DB2 or Oracle or MSSQL) was provisioned on a private subnet to establish 
+      VPC Peering from this VPC & the VPC created during current stack deployment in order to establish database connection.
+    Type: String
   ImportDemoData:
     Description: >-
       Indicate whether you want to import demo data into the database. This
@@ -264,6 +269,7 @@ Metadata:
           - MASManageDBPassword
           - MASManageDBJdbcUrl
           - MASManageDBCertificateUrl
+          - DBProvisionedVPCId
           - ImportDemoData
       - Label:
           default: MongoDB Configuration
@@ -725,7 +731,9 @@ Resources:
             - ''' '''
             - !If [MongoUseExistingInstanceCondition, !Ref DocumentDBProvisionedVPCId, ""]
             - ''' '''
-            - !Ref AWSMSKProvider	    
+            - !Ref AWSMSKProvider
+            - ''' '''
+            - !Ref DBProvisionedVPCId
             - ''' "dev" '
             - '2>&1 | tee mas-provisioning.log; '
       Tags:

--- a/aws/master-cft/paid-upi/cft-mas-core-without-ocp-license.yaml
+++ b/aws/master-cft/paid-upi/cft-mas-core-without-ocp-license.yaml
@@ -115,6 +115,11 @@ Parameters:
       Enter the HTTP or S3 location of the database's public certificate, for
       example: s3://masocp-license/db-certificate.crt
     Type: String
+  DBProvisionedVPCId:
+    Description: >-
+      Enter the VPC ID where your existing database (DB2 or Oracle or MSSQL) was provisioned on a private subnet to establish 
+      VPC Peering from this VPC & the VPC created during current stack deployment in order to establish database connection.
+    Type: String
   ImportDemoData:
     Description: >-
       Indicate whether you want to import demo data into the database. This
@@ -274,6 +279,7 @@ Metadata:
           - MASManageDBPassword
           - MASManageDBJdbcUrl
           - MASManageDBCertificateUrl
+          - DBProvisionedVPCId
           - ImportDemoData
       - Label:
           default: MongoDB Configuration
@@ -726,7 +732,9 @@ Resources:
             - ''' '''
             - !If [MongoUseExistingInstanceCondition, !Ref DocumentDBProvisionedVPCId, ""]
             - ''' '''
-            - !Ref AWSMSKProvider	    
+            - !Ref AWSMSKProvider
+            - ''' '''
+            - !Ref DBProvisionedVPCId
             - ''' "prod" '
             - '2>&1 | tee mas-provisioning.log; '
       Tags:

--- a/aws/master-cft/paid-upi/cft-mas-core.yaml
+++ b/aws/master-cft/paid-upi/cft-mas-core.yaml
@@ -106,6 +106,11 @@ Parameters:
       Enter the HTTP or S3 location of the database's public certificate, for
       example: s3://masocp-license/db-certificate.crt
     Type: String
+  DBProvisionedVPCId:
+    Description: >-
+      Enter the VPC ID where your existing database (DB2 or Oracle or MSSQL) was provisioned on a private subnet to establish 
+      VPC Peering from this VPC & the VPC created during current stack deployment in order to establish database connection.
+    Type: String
   ImportDemoData:
     Description: >-
       Indicate whether you want to import demo data into the database. This
@@ -264,6 +269,7 @@ Metadata:
           - MASManageDBPassword
           - MASManageDBJdbcUrl
           - MASManageDBCertificateUrl
+          - DBProvisionedVPCId
           - ImportDemoData
       - Label:
           default: MongoDB Configuration
@@ -716,7 +722,9 @@ Resources:
             - ''' '''
             - !If [MongoUseExistingInstanceCondition, !Ref DocumentDBProvisionedVPCId, ""]
             - ''' '''
-            - !Ref AWSMSKProvider	    
+            - !Ref AWSMSKProvider
+            - ''' '''
+            - !Ref DBProvisionedVPCId
             - ''' "prod" '
             - '2>&1 | tee mas-provisioning.log; '
       Tags:

--- a/aws/ocp-terraform/variables.tf
+++ b/aws/ocp-terraform/variables.tf
@@ -172,7 +172,7 @@ variable "worker_instance_volume_size" {
 
 variable "worker_instance_volume_type" {
   type    = string
-  default = "io1"
+  default = "gp3"
 }
 
 variable "worker_replica_count" {
@@ -197,7 +197,7 @@ variable "master_instance_volume_size" {
 
 variable "master_instance_volume_type" {
   type    = string
-  default = "io1"
+  default = "gp3"
 }
 
 variable "master_replica_count" {

--- a/helper.sh
+++ b/helper.sh
@@ -138,7 +138,7 @@ mark_provisioning_failed() {
   elif [[ $retcode -eq 35 ]]; then
     export STATUS_MSG="Failure in creating VPC peering."
   elif [[ $retcode -eq 36 ]]; then
-    export STATUS_MSG="Failure in creating IAM policy." 
+    export STATUS_MSG="Failure in creating IAM policy."
   elif [[ $retcode -eq 37 ]]; then
     export STATUS_MSG="Failure in creating Create Route. Please make sure there is no other VPCs which has matching or overlapping IPv4 CIDR blocks 10.0.0.0/16 "
   elif [[ $retcode -eq 38 ]]; then
@@ -155,6 +155,8 @@ mark_provisioning_failed() {
     export STATUS_MSG="Amazon DocumentDB is not supported in current deploy region $DEPLOY_REGION"
   elif [[ $retcode -eq 44 ]]; then
     export STATUS_MSG="Failure in fetching the CIDR block associated with Subnet"
+  elif [[ $retcode -eq 45 ]]; then
+    export STATUS_MSG="$DBProvisionedVPCId is not found in region $DEPLOY_REGION"
   fi
   export MESSAGE_TEXT=NA
   export OPENSHIFT_CLUSTER_CONSOLE_URL=NA
@@ -241,8 +243,8 @@ validate_prouduct_type() {
   log "hyperscaler in MAS_ANNOTATIONS: $MAS_ANNOTATIONS"
   if [[ $CLUSTER_TYPE == "azure" ]]; then
     export MAS_ANNOTATIONS="mas.ibm.com/hyperscalerProvider=azure,mas.ibm.com/hyperscalerChannel=azure"
-  fi   
-  log "hyperscaler in MAS_ANNOTATIONS: $MAS_ANNOTATIONS"  
+  fi
+  log "hyperscaler in MAS_ANNOTATIONS: $MAS_ANNOTATIONS"
   if [[ $OPERATIONAL_MODE == "Non-production"  ]]; then
     if [[ -n "$MAS_ANNOTATIONS" ]]; then
       export MAS_ANNOTATIONS="mas.ibm.com/operationalMode=nonproduction,${MAS_ANNOTATIONS}"

--- a/init.sh
+++ b/init.sh
@@ -66,6 +66,7 @@ export MONGO_HOSTS=${57}
 export MONGO_CA_PEM_FILE=${58}
 export DOCUMENTDB_VPC_ID=${59}
 export AWS_MSK_PROVIDER=${60}
+export DBProvisionedVPCId=${61}
 export ENV_TYPE=${61}
 export GIT_REPO_HOME=$(pwd)
 # Load helper functions
@@ -308,6 +309,7 @@ esac
 log "Below are common deployment parameters,"
 log " OPERATIONAL_MODE: $OPERATIONAL_MODE"
 log " AWS_MSK_PROVIDER: $AWS_MSK_PROVIDER"
+log " DBProvisionedVPCId: $DBProvisionedVPCId"
 log " CLUSTER_TYPE: $CLUSTER_TYPE"
 log " OFFERING_TYPE: $OFFERING_TYPE"
 log " DEPLOY_REGION: $DEPLOY_REGION"

--- a/pre-validate.sh
+++ b/pre-validate.sh
@@ -86,7 +86,7 @@ fi
 #    SCRIPT_STATUS=25
 #fi
 
-if [[ -n $DB2ProvisionedVPCId ]]; then
+if [[ -n $DBProvisionedVPCId ]]; then
 cd $GIT_REPO_HOME
 log "==== Invoke db-create-vpc-peer.sh to create VPC Peering between bootnode VPC & database provisioned VPC ID starts ===="
 log "==== This VPC peering is done to pre-validate database connection ==="

--- a/pre-validate.sh
+++ b/pre-validate.sh
@@ -86,6 +86,17 @@ fi
 #    SCRIPT_STATUS=25
 #fi
 
+if [[ -n $DB2ProvisionedVPCId ]]; then
+cd $GIT_REPO_HOME
+log "==== Invoke db-create-vpc-peer.sh to create VPC Peering between bootnode VPC & database provisioned VPC ID starts ===="
+log "==== This VPC peering is done to pre-validate database connection ==="
+    log "Existing instance of db @ VPC_ID=$DBProvisionedVPCId"
+    export ACCEPTER_VPC_ID=${DBProvisionedVPCId}
+    export REQUESTER_VPC_ID=${BOOTNODE_VPC_ID}
+
+    sh $GIT_REPO_HOME/aws/db/db-create-vpc-peer.sh
+    log "==== Invoke db-create-vpc-peer.sh ends ===="
+fi
 # JDBC CFT inputs validation and connection test
 if [[ $DEPLOY_MANAGE == "true" ]]; then
     if [[ (-z $MAS_JDBC_USER) && (-z $MAS_JDBC_PASSWORD) && (-z $MAS_JDBC_URL) && (-z $MAS_JDBC_CERT_URL) ]]; then
@@ -153,7 +164,7 @@ if [[ $DEPLOY_MANAGE == "true" ]]; then
     fi
 fi
 
-#mongo pre-validation only for AWS currently. 
+#mongo pre-validation only for AWS currently.
 if [[ $CLUSTER_TYPE == "aws" ]]; then
     log "=== pre-validate-mongo.sh started ==="
     sh $GIT_REPO_HOME/mongo/pre-validate-mongo.sh


### PR DESCRIPTION
@padmankosalaram @shajeena @amitmangalvedkar - Pls review the code changes for database on private subnet of different VPC. Also, let me know if I can remove docdb parameter in CFT file & docdb related VPC peering code because I feel Document DB related parameter field in CFT files & other code related to Document DB in our multicloud bootstrap code looks redundant & instead we can have single parameter field for database provisioned VPC ID (say DBProvisionedVPCId) & same code in our multicloud-bootstrap covering all databases such as DB2, Oracle, MSSQL, & Document DB.