### PR TITLE
networkType changed to OVNKubernetes from OpenShiftSDN for OCP 4.15.x..

### DIFF
--- a/aws/ocp-terraform/ocp/templates.tf
+++ b/aws/ocp-terraform/ocp/templates.tf
@@ -37,7 +37,7 @@ networking:
     hostPrefix: ${var.cluster_network_host_prefix}
   machineNetwork:
   - cidr: ${var.machine_network_cidr}
-  networkType: OpenShiftSDN
+  networkType: OVNKubernetes
   serviceNetwork:
   - ${var.service_network_cidr}
 platform:


### PR DESCRIPTION
networkType changed to OVNKubernetes from OpenShiftSDN for OCP 4.15.x..as the following error was seen:

Error:
[31m│[0m [0menabled client
[31m│[0m [0mlevel=error msg=failed to fetch Metadata: failed to load asset "Install
[31m│[0m [0mConfig": failed to create install config: invalid "install-config.yaml"
[31m│[0m [0mfile: networking.networkType: Invalid value: "OpenShiftSDN": networkType
[31m│[0m [0mOpenShiftSDN is not supported, please use OVNKubernetes
[31m│[0m [0m