### PR TITLE
VPC argument has been deprecated..so using domain argument instead.

### DIFF
--- a/aws/ocp-terraform/network/main.tf
+++ b/aws/ocp-terraform/network/main.tf
@@ -72,7 +72,7 @@ resource "aws_route_table_association" "master3" {
 }
 
 resource "aws_eip" "eip1" {
-  vpc = true
+  domain = "vpc"
 
   depends_on = [
     aws_vpc.cpdvpc,
@@ -80,7 +80,7 @@ resource "aws_eip" "eip1" {
 }
 resource "aws_eip" "eip2" {
   count = var.az == "multi_zone" ? 1 : 0
-  vpc   = true
+  domain = "vpc"
 
   depends_on = [
     aws_vpc.cpdvpc,
@@ -88,7 +88,7 @@ resource "aws_eip" "eip2" {
 }
 resource "aws_eip" "eip3" {
   count = var.az == "multi_zone" ? 1 : 0
-  vpc   = true
+  domain = "vpc"
 
   depends_on = [
     aws_vpc.cpdvpc,


### PR DESCRIPTION
Below error was reported and upon debugging, found that it's because VPC argument has been deprecated..so we have to use domain argument instead.
Refer this link too -->  https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-5-upgrade#resourceaws_eip 

[31m│[0m [0m[1m[31mError: [0m[0m[1mUnsupported argument[0m
[31m│[0m [0m
[31m│[0m [0m[0m  on network/main.tf line 75, in resource "aws_eip" "eip1":
[31m│[0m [0m  75:   [4mvpc[0m = true[0m
[31m│[0m [0m
[31m│[0m [0mAn argument named "vpc" is not expected here.
[31m╵[0m[0m
[31m╷[0m[0m
[31m│[0m [0m[1m[31mError: [0m[0m[1mUnsupported argument[0m
[31m│[0m [0m
[31m│[0m [0m[0m  on network/main.tf line 83, in resource "aws_eip" "eip2":
[31m│[0m [0m  83:   [4mvpc[0m   = true[0m
[31m│[0m [0m
[31m│[0m [0mAn argument named "vpc" is not expected here.
[31m╵[0m[0m
[31m╷[0m[0m
[31m│[0m [0m[1m[31mError: [0m[0m[1mUnsupported argument[0m
[31m│[0m [0m
[31m│[0m [0m[0m  on network/main.tf line 91, in resource "aws_eip" "eip3":
[31m│[0m [0m  91:   [4mvpc[0m   = true[0m
[31m│[0m [0m
[31m│[0m [0mAn argument named "vpc" is not expected here.
[31m╵[0m[0m
2025-09-30 21:53:25 Deployment return code is 1
2025-09-30 21:53:25 Deployment failed
2025-09-30 21:53:25 ===== PROVISIONING FAILED =====
2025-09-30 21:53:25  STATUS=FAILURE
2025-09-30 21:53:25  STATUS_MSG=Failure in creating OCP cluster.
2025-09-30 21:53:25 Sending completion signal to CloudFormation stack.